### PR TITLE
adds Dockerfile for OJS2

### DIFF
--- a/docker/Dockerfile-ojs2
+++ b/docker/Dockerfile-ojs2
@@ -5,7 +5,7 @@ LABEL maintainer="Deutsches Archäologisches Institut: dev@dainst.de"
 EXPOSE 80
 USER root
 
-ENV github_access_token="2f7a288dcd2870cd2239dda97bc17dfe895f18c4"
+
 ENV admin_user=admin
 ENV admin_password="password"
 ENV admin_email="email@adress.xx"

--- a/docker/Dockerfile-ojs2
+++ b/docker/Dockerfile-ojs2
@@ -1,0 +1,78 @@
+FROM php:5.6.36-apache-jessie
+# never versions of php or debian will not work with ojs2
+
+LABEL maintainer="Deutsches Archäologisches Institut: dev@dainst.de"
+EXPOSE 80
+USER root
+
+ENV github_access_token="2f7a288dcd2870cd2239dda97bc17dfe895f18c4"
+ENV admin_user=admin
+ENV admin_password="password"
+ENV admin_email="email@adress.xx"
+ENV mysql_password="ojs"
+ENV mysql_db="ojs"
+ENV enable_plugins="generic/ojs-dainst-frontpage-generator-plugin,pubIds/urnDNB,pubIds/zenon"
+
+# php settings
+RUN echo "error_reporting=E_ALL & ~E_WARNING & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED"  >> /usr/local/etc/php/php.ini
+RUN echo "date.timezone = Europe/Berlin"  >> /usr/local/etc/php/php.ini
+
+# mysql
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install git mysql-server mysql-server nano
+RUN docker-php-ext-install -j$(nproc) mysql \
+  && echo "mysql.default_socket=/run/mysqld/mysqld.sock"  >> /usr/local/etc/php/php.ini
+RUN service mysql start \
+  && sh -c "echo \"CREATE DATABASE ${mysql_db};\" | mysql" \
+  && mysqladmin -u root password ${mysql_password}
+
+# OJS2
+RUN git clone -b ojs-stable-2_4_8 https://github.com/pkp/ojs.git /var/www/html/ojs
+RUN sed -i -e 's/git:/https:/g' /var/www/html/ojs/.gitmodules \
+  && cd /var/www/html/ojs \
+  && git submodule init \
+  && git submodule update
+RUN sed -i -e 's/git:/https:/g' /var/www/html/ojs/lib/pkp/.gitmodules \
+  && cd /var/www/html/ojs/lib/pkp/ \
+  && git submodule init \
+  && git submodule update
+RUN cd /var/www/html/ojs/lib/pkp/ \
+  && sh -c 'curl -sS https://getcomposer.org/installer | php'
+RUN chmod -R 777 /var/www/html/ojs/cache \
+  && chmod -R 777 /var/www/html/ojs/public \
+  && mkdir /OJSfiles \
+  && chmod -R 777 /OJSfiles
+RUN cp /var/www/html/ojs/config.TEMPLATE.inc.php /var/www/html/ojs/config.inc.php
+
+# run installation
+RUN service mysql start  \
+  && echo "en_US\nde_DE\nutf-8\n\n\n/OJSfiles\nmd5\n${admin_user}\n${admin_password}\n${admin_password}\n${admin_email}\nmysql\nlocalhost\nroot\n${mysql_password}\n${mysql_db}\nN\ndockerizedOjs\nY\nY" > /tmp/dialog \
+  && sh -c  'cat /tmp/dialog | php /var/www/html/ojs/tools/install.php install'
+
+# frontmatter plugin dependencies
+RUN mkdir /var/www/tmp \
+  && chmod -R 777 /var/www/tmp \
+  && echo "[dainst]\ntmpPath = /var/www/tmp" >> /var/www/html/ojs/config.inc.php
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install ImageMagick Exiftool pdftk
+
+# dainst - plugins
+RUN git clone https://x-access-token:${github_access_token}@github.com/dainst/ojs-dainst-theme.git /var/www/html/ojs/plugins/themes/dainst \
+  && cd /var/www/html/ojs/plugins/themes/dainst \
+  && git submodule init \
+  && git submodule update
+RUN git clone https://x-access-token:${github_access_token}@github.com/dainst/ojs-dainst-frontpage-generator-plugin.git /var/www/html/ojs/plugins/generic/ojs-dainst-frontpage-generator-plugin \
+  && cd /var/www/html/ojs/plugins/generic/ojs-dainst-frontpage-generator-plugin \
+  && git submodule init \
+  && git submodule update
+RUN git clone https://x-access-token:${github_access_token}@github.com/dainst/ojs-dainst-zenonlink-plugin.git /var/www/html/ojs/plugins/pubIds/zenon
+RUN git clone https://x-access-token:${github_access_token}@github.com/dainst/ojs-plugin-urnDNB -b ojs2 /var/www/html/ojs/plugins/pubIds/urnDNB
+
+# set up test journal and activate plugins
+RUN git clone https://x-access-token:${github_access_token}@github.com/dainst/ojs-config-tool.git /root/ojs-config-tool
+RUN service mysql start  \
+  && php /root/ojs-config-tool/ojs2.php --theme=dainst --journal.theme=dainst --journal.plugins=${enable_plugins}
+
+# startup script
+RUN echo "#!/bin/bash\nservice mysql start\napachectl -DFOREGROUND" >> /root/startup.sh  \
+  && chmod a+x /root/startup.sh
+ENTRYPOINT ["/root/startup.sh"]


### PR DESCRIPTION
Dieser Dockerfile installiert OJS und alle dainst-plugins und richtet es basal ein. Hier kann dann ein Worker für die PublishToOJS Funktion eingebaut werden etc.