### PR TITLE
all tasks work in single workdir

### DIFF
--- a/test/service/job/test_job_config.py
+++ b/test/service/job/test_job_config.py
@@ -30,14 +30,12 @@ class JobConfigTest(unittest.TestCase):
         self.assertEqual('foreach', tasks[1]['task'])
         kwargs = tasks[1]['kwargs']
         self.assertEqual('foo', kwargs['object_id'])
-        self.assertEqual('retrieve', kwargs['prev_task'])
         self.assertEqual('*.tif', kwargs['pattern'])
         self.assertEqual('convert', kwargs['subtasks'][0]['name'])
         self.assertEqual('high', kwargs['subtasks'][0]['params']['quality'])
 
         self.assertEqual('publish', tasks[2]['task'])
         self.assertEqual('foo', tasks[2]['kwargs']['object_id'])
-        self.assertEqual('foreach', tasks[2]['kwargs']['prev_task'])
 
         job2 = job_config.generate_job("job2", "bar").chain
         self.assertTrue(

--- a/worker/convert/tasks.py
+++ b/worker/convert/tasks.py
@@ -8,7 +8,7 @@ working_dir = os.environ['WORKING_DIR']
 
 
 @celery_app.task(bind=True, name="tif_to_jpg", base=BaseTask)
-def tif2jpg(self, object_id, job_id, prev_task, parent_task, file):
+def tif2jpg(self, object_id, job_id, file):
     _, extension = os.path.splitext(file)
     new_file = file.replace(extension, '.jpg')
     convert_tif2jpg(file, new_file)

--- a/worker/convert/tasks.py
+++ b/worker/convert/tasks.py
@@ -1,15 +1,14 @@
 import os
 
+from worker.tasks import BaseTask
 from worker.convert.converter import convert_tif2jpg
 from utils.celery_client import celery_app
 
 working_dir = os.environ['WORKING_DIR']
 
 
-@celery_app.task(name="tif_to_jpg")
-def tif2jpg(object_id, job_id, prev_task, parent_task, file):
-    source = os.path.join(working_dir, job_id, object_id, prev_task)
-    target = os.path.join(working_dir, job_id, object_id, parent_task)
+@celery_app.task(bind=True, name="tif_to_jpg", base=BaseTask)
+def tif2jpg(self, object_id, job_id, prev_task, parent_task, file):
     _, extension = os.path.splitext(file)
-    new_file = file.replace(extension, '.jpg').replace(source, target)
+    new_file = file.replace(extension, '.jpg')
     convert_tif2jpg(file, new_file)

--- a/worker/pdf/tasks.py
+++ b/worker/pdf/tasks.py
@@ -7,7 +7,7 @@ from utils.celery_client import celery_app
 
 
 @celery_app.task(bind=True, name="split_pdf", base=BaseTask)
-def split_pdf(self, object_id, job_id, prev_task):
+def split_pdf(self, object_id, job_id):
     work_path = self.get_work_path(job_id)
     json_path = os.path.join(work_path, 'data_json/data.json')
     with open(json_path) as data_object:

--- a/worker/pdf/tasks.py
+++ b/worker/pdf/tasks.py
@@ -1,16 +1,16 @@
 import os
 import json
+
+from worker.tasks import BaseTask
 from worker.pdf.pdf import cut_pdf
 from utils.celery_client import celery_app
 
 
-@celery_app.task(name="split_pdf")
-def split_pdf(object_id, job_id, prev_task):
-    source = os.path.join(os.environ['WORKING_DIR'], job_id, object_id, prev_task)
-    target = os.path.join(os.environ['WORKING_DIR'], job_id, object_id, 'split_pdf')
-    json_path = os.path.join(source, 'data_json/data.json')
-    os.mkdir(target)
+@celery_app.task(bind=True, name="split_pdf", base=BaseTask)
+def split_pdf(self, object_id, job_id, prev_task):
+    work_path = self.get_work_path(job_id)
+    json_path = os.path.join(work_path, 'data_json/data.json')
     with open(json_path) as data_object:
         data = json.load(data_object)
 
-    cut_pdf(data, source, target)
+    cut_pdf(data, work_path, work_path)

--- a/worker/repository/tasks.py
+++ b/worker/repository/tasks.py
@@ -23,7 +23,7 @@ def retrieve_from_staging(self, object_id, job_id):
 
 
 @celery_app.task(bind=True, name="publish_to_repository", base=BaseTask)
-def publish_to_repository(self, object_id, job_id, prev_task):
+def publish_to_repository(self, object_id, job_id):
     work_path = self.get_work_path(job_id)
     repository_path = os.path.join(repository_dir, object_id)
     if os.path.exists(repository_path):

--- a/worker/repository/tasks.py
+++ b/worker/repository/tasks.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 
+from worker.tasks import BaseTask
 from utils.celery_client import celery_app
 
 repository_dir = os.environ['REPOSITORY_DIR']
@@ -8,24 +9,24 @@ working_dir = os.environ['WORKING_DIR']
 staging_dir = os.environ['STAGING_DIR']
 
 
-@celery_app.task(name="retrieve_from_staging", bind=True)
+@celery_app.task(bind=True, name="retrieve_from_staging", base=BaseTask)
 def retrieve_from_staging(self, object_id, job_id):
     if not os.path.exists(staging_dir):
         os.makedirs(staging_dir)
     if not os.path.exists(working_dir):
         os.makedirs(working_dir)
-    source = os.path.join(staging_dir, object_id)
-    target = os.path.join(working_dir, job_id, object_id, self.name)
-    if os.path.exists(target):
-        shutil.rmtree(target)
-    shutil.copytree(source, target)
+    staging_path = os.path.join(staging_dir, object_id)
+    work_path = self.get_work_path(job_id)
+    if os.path.exists(work_path):
+        shutil.rmtree(work_path)
+    shutil.copytree(staging_path, work_path)
 
 
-@celery_app.task(name="publish_to_repository")
-def publish_to_repository(object_id, job_id, prev_task):
-    source = os.path.join(working_dir, job_id, object_id, prev_task)
-    target = os.path.join(repository_dir, object_id)
-    if os.path.exists(target):
-        shutil.rmtree(target)
-    shutil.copytree(source, target)
+@celery_app.task(bind=True, name="publish_to_repository", base=BaseTask)
+def publish_to_repository(self, object_id, job_id, prev_task):
+    work_path = self.get_work_path(job_id)
+    repository_path = os.path.join(repository_dir, object_id)
+    if os.path.exists(repository_path):
+        shutil.rmtree(repository_path)
+    shutil.copytree(work_path, repository_path)
 

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -1,4 +1,8 @@
+import os
+
 import celery.signals
+from celery.task import Task
+
 from utils.setup_logging import setup_logging
 from utils.celery_client import celery_app
 
@@ -9,6 +13,14 @@ setup_logging()
 @celery.signals.setup_logging.connect
 def on_celery_setup_logging(**kwargs):
     pass
+
+
+class BaseTask(Task):
+
+    working_dir = os.environ['WORKING_DIR']
+
+    def get_work_path(self, job_id):
+        return os.path.join(self.working_dir, job_id)
 
 
 celery_app.autodiscover_tasks([

--- a/worker/utils/tasks.py
+++ b/worker/utils/tasks.py
@@ -9,27 +9,25 @@ from utils.celery_client import celery_app
 
 
 @celery_app.task(bind=True, name="foreach", base=BaseTask)
-def foreach(self, object_id, job_id, prev_task, subtasks, pattern='*.tif'):
+def foreach(self, object_id, job_id, subtasks, pattern='*.tif'):
     work_path = self.get_work_path(job_id)
     group_tasks = []
     for file in glob.iglob(os.path.join(work_path, pattern)):
         params = {
             'job_id': job_id,
-            'parent_task': self.name,
-            'file': file,
-            'prev_task': prev_task
+            'file': file
         }
         group_tasks.append(generate_chain(object_id, subtasks, params))
     raise self.replace(group(group_tasks))
 
 
 @celery_app.task(name="rename")
-def rename(object_id, job_id, prev_task, parent_task, file):
+def rename(object_id, job_id, file):
     new_file = file.replace('.tif', '.jpg')
     shutil.copyfile(file, new_file)
 
 
 @celery_app.task(bind=True, name="cleanup_workdir", base=BaseTask)
-def cleanup_workdir(self, object_id, job_id, prev_task):
+def cleanup_workdir(self, object_id, job_id):
     work_path = self.get_work_path(job_id)
     shutil.rmtree(work_path)

--- a/worker/utils/tasks.py
+++ b/worker/utils/tasks.py
@@ -3,19 +3,16 @@ import os
 import shutil
 from service.job.job_config import generate_chain
 from celery import group
+
+from worker.tasks import BaseTask
 from utils.celery_client import celery_app
 
-repository_dir = os.environ['REPOSITORY_DIR']
-working_dir = os.environ['WORKING_DIR']
 
-
-@celery_app.task(bind=True, name="foreach")
+@celery_app.task(bind=True, name="foreach", base=BaseTask)
 def foreach(self, object_id, job_id, prev_task, subtasks, pattern='*.tif'):
-    source = os.path.join(working_dir, job_id, object_id, prev_task)
-    target = os.path.join(working_dir, job_id, object_id, self.name)
-    os.makedirs(target)
+    work_path = self.get_work_path(job_id)
     group_tasks = []
-    for file in glob.iglob(os.path.join(source, pattern)):
+    for file in glob.iglob(os.path.join(work_path, pattern)):
         params = {
             'job_id': job_id,
             'parent_task': self.name,
@@ -28,13 +25,11 @@ def foreach(self, object_id, job_id, prev_task, subtasks, pattern='*.tif'):
 
 @celery_app.task(name="rename")
 def rename(object_id, job_id, prev_task, parent_task, file):
-    source = os.path.join(working_dir, job_id, object_id, prev_task)
-    target = os.path.join(working_dir, job_id, object_id, parent_task)
-    new_file = file.replace('.tif', '.jpg').replace(source, target)
+    new_file = file.replace('.tif', '.jpg')
     shutil.copyfile(file, new_file)
 
 
-@celery_app.task(name="cleanup_workdir")
-def cleanup_workdir(object_id, job_id, prev_task):
-    folder = os.path.join(working_dir, job_id)
-    shutil.rmtree(folder)
+@celery_app.task(bind=True, name="cleanup_workdir", base=BaseTask)
+def cleanup_workdir(self, object_id, job_id, prev_task):
+    work_path = self.get_work_path(job_id)
+    shutil.rmtree(work_path)


### PR DESCRIPTION
Instead of creating a new directory tasks now share a single working
directory that is named after the current job id. (closes #8632)

Also introduces a common base class for all tasks. (closes #8630)