### PR TITLE
use task classes instead of decorators

### DIFF
--- a/worker/convert/tasks.py
+++ b/worker/convert/tasks.py
@@ -18,4 +18,4 @@ class TifToJpgTask(BaseTask):
         convert_tif2jpg(file, new_file)
 
 
-celery_app.register_task(TifToJpgTask())
+TifToJpgTask = celery_app.register_task(TifToJpgTask())

--- a/worker/convert/tasks.py
+++ b/worker/convert/tasks.py
@@ -7,8 +7,15 @@ from utils.celery_client import celery_app
 working_dir = os.environ['WORKING_DIR']
 
 
-@celery_app.task(bind=True, name="tif_to_jpg", base=BaseTask)
-def task_tif2jpg(self, object_id, job_id, file):
-    _, extension = os.path.splitext(file)
-    new_file = file.replace(extension, '.jpg')
-    convert_tif2jpg(file, new_file)
+class TifToJpgTask(BaseTask):
+
+    name = "tif_to_jpg"
+
+    def execute_task(self):
+        file = self.get_param('file')
+        _, extension = os.path.splitext(file)
+        new_file = file.replace(extension, '.jpg')
+        convert_tif2jpg(file, new_file)
+
+
+celery_app.register_task(TifToJpgTask())

--- a/worker/pdf/tasks.py
+++ b/worker/pdf/tasks.py
@@ -2,16 +2,21 @@ import os
 import json
 
 from worker.tasks import BaseTask
-import shutil
 from worker.pdf.pdf import cut_pdf
 from utils.celery_client import celery_app
 
 
-@celery_app.task(bind=True, name="split_pdf", base=BaseTask)
-def task_split_pdf(self, object_id, job_id):
-    work_path = self.get_work_path(job_id)
-    json_path = os.path.join(work_path, 'data_json/data.json')
-    with open(json_path) as data_object:
-        data = json.load(data_object)
+class SplitPdfTask(BaseTask):
 
-    cut_pdf(data, work_path)
+    name = "split_pdf"
+
+    def execute_task(self):
+        work_path = self.get_work_path(self.job_id)
+        json_path = os.path.join(work_path, 'data_json/data.json')
+        with open(json_path) as data_object:
+            data = json.load(data_object)
+
+        cut_pdf(data, work_path)
+
+
+celery_app.register_task(SplitPdfTask())

--- a/worker/pdf/tasks.py
+++ b/worker/pdf/tasks.py
@@ -19,4 +19,4 @@ class SplitPdfTask(BaseTask):
         cut_pdf(data, work_path)
 
 
-celery_app.register_task(SplitPdfTask())
+SplitPdfTask = celery_app.register_task(SplitPdfTask())

--- a/worker/repository/tasks.py
+++ b/worker/repository/tasks.py
@@ -34,3 +34,6 @@ class PublishToRepositoryTask(BaseTask):
         if os.path.exists(repository_path):
             shutil.rmtree(repository_path)
         shutil.copytree(work_path, repository_path)
+
+
+PublishToRepositoryTask = celery_app.register_task(PublishToRepositoryTask())

--- a/worker/repository/tasks.py
+++ b/worker/repository/tasks.py
@@ -9,23 +9,28 @@ working_dir = os.environ['WORKING_DIR']
 staging_dir = os.environ['STAGING_DIR']
 
 
-@celery_app.task(bind=True, name="retrieve_from_staging", base=BaseTask)
-def task_retrieve_from_staging(self, object_id, job_id):
-    if not os.path.exists(staging_dir):
-        os.makedirs(staging_dir)
-    if not os.path.exists(working_dir):
-        os.makedirs(working_dir)
-    staging_path = os.path.join(staging_dir, object_id)
-    work_path = self.get_work_path(job_id)
-    if os.path.exists(work_path):
-        shutil.rmtree(work_path)
-    shutil.copytree(staging_path, work_path)
+class RetrieveFromStagingTask(BaseTask):
+
+    name = "retrieve_from_staging"
+
+    def execute_task(self):
+        staging_path = os.path.join(staging_dir, self.object_id)
+        work_path = self.get_work_path(self.job_id)
+        if os.path.exists(work_path):
+            shutil.rmtree(work_path)
+        shutil.copytree(staging_path, work_path)
 
 
-@celery_app.task(bind=True, name="publish_to_repository", base=BaseTask)
-def task_publish_to_repository(self, object_id, job_id):
-    work_path = self.get_work_path(job_id)
-    repository_path = os.path.join(repository_dir, object_id)
-    if os.path.exists(repository_path):
-        shutil.rmtree(repository_path)
-    shutil.copytree(work_path, repository_path)
+RetrieveFromStagingTask = celery_app.register_task(RetrieveFromStagingTask())
+
+
+class PublishToRepositoryTask(BaseTask):
+
+    name = "publish_to_repository"
+
+    def execute_task(self):
+        work_path = self.get_work_path(self.job_id)
+        repository_path = os.path.join(repository_dir, self.object_id)
+        if os.path.exists(repository_path):
+            shutil.rmtree(repository_path)
+        shutil.copytree(work_path, repository_path)

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -56,12 +56,12 @@ class BaseTask(Task):
         try:
             self.job_id = params['job_id']
         except KeyError:
-            raise KeyError(f"job_id has to be set before running a task")
+            raise KeyError("job_id has to be set before running a task")
 
         try:
             self.object_id = params['object_id']
         except KeyError:
-            raise KeyError(f"object_id has to be set before running a task")
+            raise KeyError("object_id has to be set before running a task")
 
 
 celery_app.autodiscover_tasks([

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -2,6 +2,7 @@ import os
 
 import celery.signals
 from celery.task import Task
+from abc import abstractmethod
 
 from utils.setup_logging import setup_logging
 from utils.celery_client import celery_app
@@ -16,11 +17,51 @@ def on_celery_setup_logging(**kwargs):
 
 
 class BaseTask(Task):
+    """
+    This is the abstract base class for all tasks in cilantro.
+    It provides parameter handling and utility methods for accessing
+    the file system.
+    Implementations should override the execute_task() method.
+    """
 
     working_dir = os.environ['WORKING_DIR']
+    params = {}
+    job_id = None
+    object_id = None
 
     def get_work_path(self, job_id):
         return os.path.join(self.working_dir, job_id)
+
+    def run(self, **params):
+        self._init_params(params)
+        self.execute_task()
+
+    def get_param(self, key):
+        try:
+            return self.params[key]
+        except KeyError:
+            raise KeyError(f"Mandatory parameter {key} is missing"
+                           f"for {self.__class__.__name__}")
+
+    @abstractmethod
+    def execute_task(self):
+        """
+        This method has to be implemented by all subclassed tasks and includes
+        the actual implementation logic of the specific task.
+        :return:
+        """
+
+    def _init_params(self, params):
+        self.params = params
+        try:
+            self.job_id = params['job_id']
+        except KeyError:
+            raise KeyError(f"job_id has to be set before running a task")
+
+        try:
+            self.object_id = params['object_id']
+        except KeyError:
+            raise KeyError(f"object_id has to be set before running a task")
 
 
 celery_app.autodiscover_tasks([

--- a/worker/utils/tasks.py
+++ b/worker/utils/tasks.py
@@ -37,3 +37,6 @@ class CleanupWorkdirTask(BaseTask):
     def execute_task(self):
         work_path = self.get_work_path(self.job_id)
         shutil.rmtree(work_path)
+
+
+CleanupWorkdirTask = celery_app.register_task(CleanupWorkdirTask())

--- a/worker/utils/tasks.py
+++ b/worker/utils/tasks.py
@@ -8,26 +8,32 @@ from worker.tasks import BaseTask
 from utils.celery_client import celery_app
 
 
-@celery_app.task(bind=True, name="foreach", base=BaseTask)
-def foreach(self, object_id, job_id, subtasks, pattern='*.tif'):
-    work_path = self.get_work_path(job_id)
-    group_tasks = []
-    for file in glob.iglob(os.path.join(work_path, pattern)):
-        params = {
-            'job_id': job_id,
-            'file': file
-        }
-        group_tasks.append(generate_chain(object_id, subtasks, params))
-    raise self.replace(group(group_tasks))
+class ForeachTask(BaseTask):
+
+    name = "foreach"
+
+    def execute_task(self):
+        pattern = self.get_param('pattern')
+        subtasks = self.get_param('subtasks')
+        work_path = self.get_work_path(self.job_id)
+        group_tasks = []
+        for file in glob.iglob(os.path.join(work_path, pattern)):
+            params = {
+                'job_id': self.job_id,
+                'file': file
+            }
+            chain = generate_chain(self.object_id, subtasks, params)
+            group_tasks.append(chain)
+        raise self.replace(group(group_tasks))
 
 
-@celery_app.task(name="rename")
-def rename(object_id, job_id, file):
-    new_file = file.replace('.tif', '.jpg')
-    shutil.copyfile(file, new_file)
+ForeachTask = celery_app.register_task(ForeachTask())
 
 
-@celery_app.task(bind=True, name="cleanup_workdir", base=BaseTask)
-def cleanup_workdir(self, object_id, job_id):
-    work_path = self.get_work_path(job_id)
-    shutil.rmtree(work_path)
+class CleanupWorkdirTask(BaseTask):
+
+    name = "cleanup_workdir"
+
+    def execute_task(self):
+        work_path = self.get_work_path(self.job_id)
+        shutil.rmtree(work_path)


### PR DESCRIPTION
This allows common operations such as parameter handling
to be performed in the base class.

The base class implements the template method pattern.