### PR TITLE
Unordered staging

### DIFF
--- a/.idea/cilantro.iml
+++ b/.idea/cilantro.iml
@@ -6,9 +6,9 @@
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/service" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/worker" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/utils" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/workers" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
     <orderEntry type="jdk" jdkName="Python 3.6 (cilantro)" jdkType="Python SDK" />

--- a/config/job_types/ingest_book.yml
+++ b/config/job_types/ingest_book.yml
@@ -1,3 +1,6 @@
+params:
+  paths: list
+
 tasks:
   - retrieve_from_staging
   - foreach: "*.[tT][iI][fF]*"

--- a/config/job_types/ingest_journal.yml
+++ b/config/job_types/ingest_journal.yml
@@ -1,3 +1,6 @@
+params:
+  paths: list
+
 tasks:
   - retrieve_from_staging
   - convert.split_pdf

--- a/config/job_types/nlp_pipe.yml
+++ b/config/job_types/nlp_pipe.yml
@@ -1,3 +1,6 @@
+params:
+  paths: list
+
 tasks:
   - retrieve_from_staging
   - nlp.annotate

--- a/service/job/job_config.py
+++ b/service/job/job_config.py
@@ -177,6 +177,8 @@ def _init_default_params(params):
             default_params[param_name] = False
         elif param_type == 'string':
             default_params[param_name] = ''
+        elif param_type == 'list':
+            default_params[param_name] = []
         else:
             raise ConfigParseException(
                 f"Parameter type '{param_type}' for "

--- a/service/job/job_controller.py
+++ b/service/job/job_controller.py
@@ -20,10 +20,10 @@ def get_job_config():
 job_controller = Blueprint('job', __name__)
 
 
-@job_controller.route('/<job_type>/<object_id>', methods=['POST'])
-def job_create(job_type, object_id):
+@job_controller.route('/<job_type>', methods=['POST'])
+def job_create(job_type):
     params = request.get_json(force=True, silent=True)
-    job = get_job_config().generate_job(job_type, object_id, params)
+    job = get_job_config().generate_job(job_type, params)
     task = job.run()
     logger = logging.getLogger(__name__)
     logger.info(f"created job with id: {task.id}")

--- a/service/job/job_controller.py
+++ b/service/job/job_controller.py
@@ -7,6 +7,10 @@ from service.job.job_config import JobConfig
 
 
 def get_job_config():
+    """
+    Get the job config singleton or creates it if it does not exist already
+    :return JobConfig:
+    """
     job_config = getattr(g, '_job_config', None)
     if job_config is None:
         job_config = g._job_config = JobConfig()

--- a/test/integration/job_type_test.py
+++ b/test/integration/job_type_test.py
@@ -89,20 +89,24 @@ class JobTypeTest(unittest.TestCase):
         data = json.loads(response.get_data(as_text=True))
         return data['status']
 
-    def post_job(self, job_type, object_id):
-        response = self.client.post(f'/job/{job_type}/{object_id}')
+    def post_job(self, job_type, data):
+        response = self.client.post(
+            f'/job/{job_type}',
+            data=json.dumps(data),
+            content_type='application/json'
+        )
         return json.loads(response.get_data(as_text=True))
 
-    def stage_resource(self, folder, object_id):
-        source = os.path.join(self.resource_dir, folder, object_id)
-        target = os.path.join(self.staging_dir, object_id)
+    def stage_resource(self, folder, path):
+        source = os.path.join(self.resource_dir, folder, path)
+        target = os.path.join(self.staging_dir, path)
         try:
             shutil.copytree(source, target)
         except FileExistsError:
             pass
 
-    def unstage_resource(self, object_id):
-        source = os.path.join(self.staging_dir, object_id)
+    def unstage_resource(self, path):
+        source = os.path.join(self.staging_dir, path)
         try:
             shutil.rmtree(source)
         except FileNotFoundError:

--- a/test/integration/job_type_test.py
+++ b/test/integration/job_type_test.py
@@ -55,10 +55,8 @@ class JobTypeTest(unittest.TestCase):
         waited = 0
         success = False
         while not success:
-            print("---")
             for task_id in task_ids:
                 status = self.get_status(task_id)
-                print(f"{task_id}: {status}")
                 if status == 'FAILURE':
                     raise AssertionError("child task in FAILURE state")
                 elif status == 'SUCCESS':

--- a/test/integration/test_ingest_book.py
+++ b/test/integration/test_ingest_book.py
@@ -6,15 +6,16 @@ class IngestBookTest(JobTypeTest):
     def test_success(self):
         self.stage_resource('objects', 'some_tiffs')
 
-        data = self.post_job('ingest_book', 'some_tiffs')
+        data = self.post_job('ingest_book', {'paths': ['some_tiffs']})
+        job_id = data['job_id']
         self.assertEqual('Accepted', data['status'])
         self.assert_job_successful(data['task_ids'])
-        self.assert_file_in_repository('some_tiffs', 'test.jpg')
-        self.assert_file_in_repository('some_tiffs', 'test.converted.pdf')
-        self.assert_file_in_repository('some_tiffs', 'merged.pdf')
+        self.assert_file_in_repository(job_id, 'test.jpg')
+        self.assert_file_in_repository(job_id, 'test.converted.pdf')
+        self.assert_file_in_repository(job_id, 'merged.pdf')
 
         self.unstage_resource('some_tiffs')
-        self.remove_object_from_repository('some_tiffs')
+        self.remove_object_from_repository(job_id)
 
     '''
     commented out until proper solution for

--- a/test/integration/test_ingest_journal.py
+++ b/test/integration/test_ingest_journal.py
@@ -6,12 +6,13 @@ class IngestJournalTest(JobTypeTest):
     def test_success(self):
         self.stage_resource('objects', 'pdf')
 
-        job = self.post_job('ingest_journal', 'pdf')
-        self.assertEqual('Accepted', job['status'])
-        self.assert_status(job['job_id'], 'SUCCESS')
+        data = self.post_job('ingest_journal', {'paths': ['pdf']})
+        job_id = data['job_id']
+        self.assertEqual('Accepted', data['status'])
+        self.assert_status(job_id, 'SUCCESS')
 
         files_generated = [f'e2e-testing.pdf.0.pdf', f'e2e-testing.pdf.1.pdf']
         for file in files_generated:
-            self.assert_file_in_repository('pdf', file)
+            self.assert_file_in_repository(job_id, file)
         self.unstage_resource('pdf')
-        self.remove_object_from_repository('pdf')
+        self.remove_object_from_repository(job_id)

--- a/test/integration/test_nlp_worker.py
+++ b/test/integration/test_nlp_worker.py
@@ -6,9 +6,10 @@ class NlpWorkerTest(JobTypeTest):
     def test_success(self):
         self.stage_resource('objects', 'nlp')
 
-        job = self.post_job('nlp_pipe', 'nlp')
-        self.assertEqual('Accepted', job['status'])
-        self.assert_status(job['job_id'], 'SUCCESS')
+        data = self.post_job('nlp_pipe', {'paths': ['nlp']})
+        job_id = data['job_id']
+        self.assertEqual('Accepted', data['status'])
+        self.assert_status(job_id, 'SUCCESS')
 
         self.unstage_resource('nlp')
-        self.remove_object_from_repository('nlp')
+        self.remove_object_from_repository(job_id)

--- a/test/service/job/test_job_config.py
+++ b/test/service/job/test_job_config.py
@@ -13,7 +13,7 @@ class JobConfigTest(unittest.TestCase):
         os.environ['CONFIG_DIR'] = "test/resources/configs/config_valid"
 
         job_config = JobConfig()
-        job1 = job_config.generate_job("job1", "foo").chain
+        job1 = job_config.generate_job("job1").chain
         self.assertTrue(
             isinstance(job1, Signature),
             f"job1 is an instance of '{type(job1)}, expected 'Signature'"
@@ -24,19 +24,16 @@ class JobConfigTest(unittest.TestCase):
         self.assertEqual(3, len(tasks))
 
         self.assertEqual('retrieve', tasks[0]['task'])
-        self.assertEqual('foo', tasks[0]['kwargs']['object_id'])
 
         self.assertEqual('foreach', tasks[1]['task'])
         kwargs = tasks[1]['kwargs']
-        self.assertEqual('foo', kwargs['object_id'])
         self.assertEqual('*.tif', kwargs['pattern'])
         self.assertEqual('convert', kwargs['subtasks'][0]['name'])
         self.assertEqual('high', kwargs['subtasks'][0]['params']['quality'])
 
         self.assertEqual('publish', tasks[2]['task'])
-        self.assertEqual('foo', tasks[2]['kwargs']['object_id'])
 
-        job2 = job_config.generate_job("job2", "bar").chain
+        job2 = job_config.generate_job("job2").chain
         self.assertTrue(
             isinstance(job2, Signature),
             f"job2 is an instance of '{type(job1)}', expected 'Signature'"
@@ -53,7 +50,7 @@ class JobConfigTest(unittest.TestCase):
         os.environ['CONFIG_DIR'] = "test/resources/configs/config_valid"
         job_config = JobConfig()
         self.assertRaises(UnknownJobTypeException, job_config.generate_job,
-                          "job3", "foo")
+                          "job3")
 
     def test_invalid_yaml(self):
         os.environ['CONFIG_DIR'] = "test/resources/configs/config_invalid_yaml"
@@ -72,7 +69,7 @@ class JobConfigTest(unittest.TestCase):
 
         job_config = JobConfig()
 
-        job = job_config.generate_job("job1", "foo").chain
+        job = job_config.generate_job("job1").chain
 
         tasks = job.tasks
 
@@ -84,7 +81,7 @@ class JobConfigTest(unittest.TestCase):
 
         job_config = JobConfig()
 
-        job = job_config.generate_job("job1", "foo", {'do_task2': True}).chain
+        job = job_config.generate_job("job1", {'do_task2': True}).chain
 
         tasks = job.tasks
 
@@ -96,7 +93,7 @@ class JobConfigTest(unittest.TestCase):
 
         job_config = JobConfig()
 
-        job = job_config.generate_job("job1", "foo", {"do_task2": True}).chain
+        job = job_config.generate_job("job1", {"do_task2": True}).chain
 
         tasks = job.tasks
         self.assertEqual(3, len(tasks))
@@ -110,7 +107,7 @@ class JobConfigTest(unittest.TestCase):
 
         job_config = JobConfig()
 
-        job = job_config.generate_job("job1", "foo", {"do_task2": False}).chain
+        job = job_config.generate_job("job1", {"do_task2": False}).chain
 
         tasks = job.tasks
         self.assertEqual(2, len(tasks))
@@ -123,7 +120,7 @@ class JobConfigTest(unittest.TestCase):
 
         job_config = JobConfig()
 
-        job = job_config.generate_job("job1", "foo").chain
+        job = job_config.generate_job("job1").chain
 
         tasks = job.tasks
         self.assertEqual(2, len(tasks))
@@ -136,7 +133,7 @@ class JobConfigTest(unittest.TestCase):
 
         job_config = JobConfig()
 
-        job = job_config.generate_job("job2", "foo", {"do_task2": True}).chain
+        job = job_config.generate_job("job2", {"do_task2": True}).chain
 
         tasks = job.tasks
         self.assertEqual(4, len(tasks))
@@ -151,7 +148,7 @@ class JobConfigTest(unittest.TestCase):
 
         job_config = JobConfig()
 
-        job = job_config.generate_job("job2", "foo", {"do_task2": False}).chain
+        job = job_config.generate_job("job2", {"do_task2": False}).chain
 
         tasks = job.tasks
         self.assertEqual(3, len(tasks))
@@ -165,7 +162,7 @@ class JobConfigTest(unittest.TestCase):
 
         job_config = JobConfig()
 
-        job = job_config.generate_job("job2", "foo").chain
+        job = job_config.generate_job("job2").chain
 
         tasks = job.tasks
         self.assertEqual(3, len(tasks))
@@ -179,7 +176,7 @@ class JobConfigTest(unittest.TestCase):
 
         job_config = JobConfig()
 
-        job = job_config.generate_job("job3", "foo", {"skip_task2": True}).chain
+        job = job_config.generate_job("job3", {"skip_task2": True}).chain
 
         tasks = job.tasks
         self.assertEqual(2, len(tasks))
@@ -192,7 +189,7 @@ class JobConfigTest(unittest.TestCase):
 
         job_config = JobConfig()
 
-        job = job_config.generate_job("job3", "foo", {"skip_task2": False}).chain
+        job = job_config.generate_job("job3", {"skip_task2": False}).chain
 
         tasks = job.tasks
         self.assertEqual(3, len(tasks))
@@ -206,7 +203,7 @@ class JobConfigTest(unittest.TestCase):
 
         job_config = JobConfig()
 
-        job = job_config.generate_job("job3", "foo").chain
+        job = job_config.generate_job("job3").chain
 
         tasks = job.tasks
         self.assertEqual(3, len(tasks))
@@ -221,7 +218,7 @@ class JobConfigTest(unittest.TestCase):
         job_config = JobConfig()
 
         with self.assertRaises(RequestParameterException):
-            job_config.generate_job("job1", "foo", {"skip_task2": True})
+            job_config.generate_job("job1", {"skip_task2": True})
 
     def test_invalid_request_param_type(self):
         os.environ['CONFIG_DIR'] = "test/resources/configs/config_if"
@@ -229,4 +226,4 @@ class JobConfigTest(unittest.TestCase):
         job_config = JobConfig()
 
         with self.assertRaises(RequestParameterException):
-            job_config.generate_job("job1", "foo", {"do_task2": "foo"})
+            job_config.generate_job("job1", {"do_task2": "foo"})

--- a/workers/base_task.py
+++ b/workers/base_task.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import shutil
 from abc import abstractmethod
 
 import celery.signals
@@ -33,8 +34,11 @@ class BaseTask(Task):
     job_id = None
     log = logging.getLogger(__name__)
 
-    def get_work_path(self, job_id):
-        return os.path.join(self.working_dir, job_id)
+    def get_work_path(self):
+        work_path = os.path.join(self.working_dir, self.job_id)
+        if not os.path.exists(work_path):
+            os.mkdir(work_path)
+        return work_path
 
     def run(self, **params):
         self._init_params(params)

--- a/workers/base_task.py
+++ b/workers/base_task.py
@@ -31,7 +31,6 @@ class BaseTask(Task):
     working_dir = os.environ['WORKING_DIR']
     params = {}
     job_id = None
-    object_id = None
     log = logging.getLogger(__name__)
 
     def get_work_path(self, job_id):
@@ -63,9 +62,4 @@ class BaseTask(Task):
             self.job_id = params['job_id']
         except KeyError:
             raise KeyError("job_id has to be set before running a task")
-
-        try:
-            self.object_id = params['object_id']
-        except KeyError:
-            raise KeyError("object_id has to be set before running a task")
         self.log.debug(f"initialized params: {self.params}")

--- a/workers/convert/pdf/tasks.py
+++ b/workers/convert/pdf/tasks.py
@@ -11,7 +11,7 @@ class SplitPdfTask(BaseTask):
     name = "convert.split_pdf"
 
     def execute_task(self):
-        work_path = self.get_work_path(self.job_id)
+        work_path = self.get_work_path()
         json_path = os.path.join(work_path, 'data.json')
         with open(json_path, 'r') as data_object:
             data = json.load(data_object)
@@ -38,7 +38,7 @@ class PdfMergeConverted(BaseTask):
     name = "convert.pdf_merge_converted"
 
     def execute_task(self):
-        work_path = self.get_work_path(self.job_id)
+        work_path = self.get_work_path()
         files = list_files(work_path, '.converted.pdf')
         pdf_merge(files, work_path + '/merged.pdf')  # TODO incorporate JSON data for the filename and metadatas.
 

--- a/workers/convert/pdf/tasks.py
+++ b/workers/convert/pdf/tasks.py
@@ -12,7 +12,7 @@ class SplitPdfTask(BaseTask):
 
     def execute_task(self):
         work_path = self.get_work_path(self.job_id)
-        json_path = os.path.join(work_path, 'data_json/data.json')
+        json_path = os.path.join(work_path, 'data.json')
         with open(json_path, 'r') as data_object:
             data = json.load(data_object)
         data = cut_pdf(data, work_path, work_path)

--- a/workers/default/metadata/loader.py
+++ b/workers/default/metadata/loader.py
@@ -3,7 +3,7 @@ import os
 
 
 def load_metadata(path):
-    json_path = os.path.join(path, 'data_json/data.json')
+    json_path = os.path.join(path, 'data.json')
     with open(json_path) as data_object:
         data = json.load(data_object)
     return data

--- a/workers/default/repository/tasks.py
+++ b/workers/default/repository/tasks.py
@@ -14,11 +14,18 @@ class RetrieveFromStagingTask(BaseTask):
     name = "retrieve_from_staging"
 
     def execute_task(self):
-        staging_path = os.path.join(staging_dir, self.object_id)
+        staging_path = os.path.join(staging_dir)
+
+        # TODO: move to base class
         work_path = self.get_work_path(self.job_id)
         if os.path.exists(work_path):
             shutil.rmtree(work_path)
-        shutil.copytree(staging_path, work_path)
+
+        files = self.get_param('files')
+        for file in files:
+            src = os.path.join(staging_path, file)
+            dest = os.path.join(work_path, file)
+            shutil.copyfile(src, dest)
 
 
 RetrieveFromStagingTask = celery_app.register_task(RetrieveFromStagingTask())
@@ -30,7 +37,7 @@ class PublishToRepositoryTask(BaseTask):
 
     def execute_task(self):
         work_path = self.get_work_path(self.job_id)
-        repository_path = os.path.join(repository_dir, self.object_id)
+        repository_path = os.path.join(repository_dir, self.job_id)
         if os.path.exists(repository_path):
             shutil.rmtree(repository_path)
         shutil.copytree(work_path, repository_path)

--- a/workers/default/repository/tasks.py
+++ b/workers/default/repository/tasks.py
@@ -29,16 +29,10 @@ class RetrieveFromStagingTask(BaseTask):
     def execute_task(self):
         staging_path = os.path.join(staging_dir)
 
-        # TODO: move to base class
-        work_path = self.get_work_path(self.job_id)
-        if os.path.exists(work_path):
-            shutil.rmtree(work_path)
-        os.mkdir(work_path)
-
         paths = self.get_param('paths')
         for path in paths:
             src = os.path.join(staging_path, path)
-            dest = os.path.join(work_path)
+            dest = os.path.join(self.get_work_path())
             _copy_path(src, dest)
 
 
@@ -50,7 +44,7 @@ class PublishToRepositoryTask(BaseTask):
     name = "publish_to_repository"
 
     def execute_task(self):
-        work_path = self.get_work_path(self.job_id)
+        work_path = self.get_work_path()
         repository_path = os.path.join(repository_dir, self.job_id)
         if os.path.exists(repository_path):
             shutil.rmtree(repository_path)

--- a/workers/default/repository/tasks.py
+++ b/workers/default/repository/tasks.py
@@ -15,7 +15,6 @@ def _copy_path(src, dest):
     :param str src:
     :param str dest:
     """
-    print(f"src: {src}, dest: {dest}")
     if os.path.isdir(src):
         for path in os.listdir(src):
             _copy_path(os.path.join(src, path), dest)

--- a/workers/default/repository/tasks.py
+++ b/workers/default/repository/tasks.py
@@ -9,6 +9,20 @@ working_dir = os.environ['WORKING_DIR']
 staging_dir = os.environ['STAGING_DIR']
 
 
+def _copy_path(src, dest):
+    """
+    Recursively copies and flattens the given paths
+    :param str src:
+    :param str dest:
+    """
+    print(f"src: {src}, dest: {dest}")
+    if os.path.isdir(src):
+        for path in os.listdir(src):
+            _copy_path(os.path.join(src, path), dest)
+    else:
+        shutil.copy2(src, dest)
+
+
 class RetrieveFromStagingTask(BaseTask):
 
     name = "retrieve_from_staging"
@@ -20,12 +34,13 @@ class RetrieveFromStagingTask(BaseTask):
         work_path = self.get_work_path(self.job_id)
         if os.path.exists(work_path):
             shutil.rmtree(work_path)
+        os.mkdir(work_path)
 
         paths = self.get_param('paths')
         for path in paths:
             src = os.path.join(staging_path, path)
-            dest = os.path.join(work_path, path)
-            shutil.copytree(src, dest)
+            dest = os.path.join(work_path)
+            _copy_path(src, dest)
 
 
 RetrieveFromStagingTask = celery_app.register_task(RetrieveFromStagingTask())

--- a/workers/default/repository/tasks.py
+++ b/workers/default/repository/tasks.py
@@ -21,11 +21,11 @@ class RetrieveFromStagingTask(BaseTask):
         if os.path.exists(work_path):
             shutil.rmtree(work_path)
 
-        files = self.get_param('files')
-        for file in files:
-            src = os.path.join(staging_path, file)
-            dest = os.path.join(work_path, file)
-            shutil.copyfile(src, dest)
+        paths = self.get_param('paths')
+        for path in paths:
+            src = os.path.join(staging_path, path)
+            dest = os.path.join(work_path, path)
+            shutil.copytree(src, dest)
 
 
 RetrieveFromStagingTask = celery_app.register_task(RetrieveFromStagingTask())

--- a/workers/default/utils/tasks.py
+++ b/workers/default/utils/tasks.py
@@ -16,7 +16,7 @@ class ForeachTask(BaseTask):
     def execute_task(self):
         pattern = self.get_param('pattern')
         subtasks = self.get_param('subtasks')
-        work_path = self.get_work_path(self.job_id)
+        work_path = self.get_work_path()
         group_tasks = []
         for file in glob.iglob(os.path.join(work_path, pattern)):
             params = {
@@ -36,7 +36,7 @@ class CleanupWorkdirTask(BaseTask):
     name = "cleanup_workdir"
 
     def execute_task(self):
-        work_path = self.get_work_path(self.job_id)
+        work_path = self.get_work_path()
         shutil.rmtree(work_path)
 
 

--- a/workers/default/utils/tasks.py
+++ b/workers/default/utils/tasks.py
@@ -23,7 +23,7 @@ class ForeachTask(BaseTask):
                 'job_id': self.job_id,
                 'file': file
             }
-            chain = generate_chain(self.object_id, subtasks, params)
+            chain = generate_chain(subtasks, params)
             group_tasks.append(chain)
         raise self.replace(group(group_tasks))
 

--- a/workers/default/xml/tasks.py
+++ b/workers/default/xml/tasks.py
@@ -10,7 +10,7 @@ class GenerateMarcXMLTask(BaseTask):
     name = "generate_marc_xml"
 
     def execute_task(self):
-        work_path = self.get_work_path(self.job_id)
+        work_path = self.get_work_path()
         data = load_metadata(work_path)
         xml_template_string = _read_template_file(self.get_param('xml_template_path'))
         generate_marc_xml(work_path, data, xml_template_string)
@@ -23,7 +23,7 @@ class GenerateXMLTask(BaseTask):
     name = "generate_xml"
 
     def execute_task(self):
-        work_path = self.get_work_path(self.job_id)
+        work_path = self.get_work_path()
         data = load_metadata(work_path)
         xml_template_string = _read_template_file(self.get_param('xml_template_path'))
         generate_xml(work_path, data, xml_template_string)

--- a/workers/nlp/annotate/tasks.py
+++ b/workers/nlp/annotate/tasks.py
@@ -15,7 +15,7 @@ class AnnotateTask(BaseTask):
     name = "nlp.annotate"
 
     def execute_task(self):
-        work_path = self.get_work_path(self.job_id)
+        work_path = self.get_work_path()
         json_path = os.path.join(work_path, 'nlp_params.json')
         text_path = os.path.join(work_path, 'nlp_text.txt')
 


### PR DESCRIPTION
The object of the task chain will no longer be defined by the name of
the folder in the staging area. Instead, the files that should be
handled in a job will be given to retrieve_from_staging as a parameter.

Therefore there is no longer a need for providing an object_id when
creating a job. Depending on the job type the id can now be generated
or read from the metadata as part of the job chain.

Since retrieve_staging needs an id under which the result of the chain
is published it uses the job_id until proper mechanisms for reading
the object id are in place.

In addition to being able to provide the names of the files that will
be retrieved from the staging area, provided folders will also be
copied (recursively) to the working directory. Files from folders given in the paths parameter are copied to the root of the job directory in the workspace.

Also, the JSON metadata file is now expected to be at the root of the job
directory in the workspace.