### PR TITLE
Use regex pattern in foreach task

### DIFF
--- a/config/job_types/ingest_book.yml
+++ b/config/job_types/ingest_book.yml
@@ -1,8 +1,8 @@
 tasks:
   - retrieve_from_staging
-  - foreach: "*.[tT][iI][fF]*"
+  - foreach: "\\.(tif|tiff|TIF|TIFF)$"
     do: convert.tif_to_jpg
-  - foreach: "*.[jJ][pP][gG]*"
+  - foreach: "\\.(jpg|jpeg|JPG|JPEG)$"
     do: convert.jpg_to_pdf
   - convert.pdf_merge_converted
   - publish_to_repository

--- a/workers/default/utils/tasks.py
+++ b/workers/default/utils/tasks.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import re
 import shutil
 
 from celery import group
@@ -18,10 +19,12 @@ class ForeachTask(BaseTask):
         subtasks = self.get_param('subtasks')
         work_path = self.get_work_path(self.job_id)
         group_tasks = []
-        for file in glob.iglob(os.path.join(work_path, pattern)):
+        regex = re.compile(pattern)
+        files = [f for f in os.listdir(work_path) if regex.search(f)]
+        for file in files:
             params = {
                 'job_id': self.job_id,
-                'file': file
+                'file': os.path.join(work_path, file)
             }
             chain = generate_chain(self.object_id, subtasks, params)
             group_tasks.append(chain)


### PR DESCRIPTION
Instead of using glob the pattern passed to foreach is now interpreted
as a regular expression. This allows for more elaborated patterns.

Currently the pattern only matches files in the root of the working
directory. This should probably be expanded when the handling of
subfolders has been defined.

Closes #8695