### PR TITLE
Fix one-element task chain error

### DIFF
--- a/service/job/job.py
+++ b/service/job/job.py
@@ -27,5 +27,13 @@ class Job:
         return self.chain.apply_async(task_id=self.id)
 
     def _set_job_id_for_tasks(self):
-        for task in self.chain.tasks:
+        # When there is only one element in the task chain, the tasks property
+        # is not available.
+        # In this case we just take the chain itself as a list as a workaround.
+        if hasattr(self.chain, 'tasks'):
+            task_chain = self.chain.tasks
+        else:
+            task_chain = [self.chain]
+
+        for task in task_chain:
             task.kwargs['job_id'] = self.id


### PR DESCRIPTION
Habe den Fix mal als Pull Request angelegt, weil ich nicht ganz sicher bin, was da die Ursache ist. Vielleicht hat ja jemand Lust da nochmal reinzuschauen.
Könnte ein Celery-Bug sein, habe aber nichts entsprechendes gefunden.
Ist 'nur' jetzt einen Workaround der das abfängt.

---

When there is only one element in the task chain, the tasks property
is not available. In this case we just take the chain itself as a
list as a workaround.

Resolves: #8664