### PR TITLE
Add job_type controller

### DIFF
--- a/run_service.py
+++ b/run_service.py
@@ -5,6 +5,7 @@ from flask_cors import CORS
 from utils.setup_logging import setup_logging
 from service.front_controller import front_controller
 from service.job.job_controller import job_controller
+from service.job.job_type_controller import job_type_controller
 from service.staging.staging_controller import staging_controller
 from service.repository.repository_controller import repository_controller
 
@@ -15,5 +16,6 @@ CORS(app)
 
 app.register_blueprint(front_controller)
 app.register_blueprint(job_controller, url_prefix="/job")
+app.register_blueprint(job_type_controller, url_prefix="/job_types")
 app.register_blueprint(staging_controller, url_prefix="/staging")
 app.register_blueprint(repository_controller, url_prefix="/repository")

--- a/service/job/job_type_controller.py
+++ b/service/job/job_type_controller.py
@@ -1,0 +1,29 @@
+import os
+import yaml
+
+from flask import Blueprint, jsonify
+
+job_type_controller = Blueprint('job_types', __name__)
+
+config_dir = os.environ['CONFIG_DIR']
+job_types_dir = os.path.join(config_dir, 'job_types')
+
+
+@job_type_controller.route('', methods=['GET'])
+def get_job_types():
+    """
+    Returns a JSON list of available job types and their meta information.
+
+    :return str: JSON list of objecta containing the type names and
+                 the about information from the file
+    """
+    job_types = []
+    for job_type_file in os.listdir(job_types_dir):
+        job_name = job_type_file.rsplit('.', 1)[0]
+        with open(os.path.join(job_types_dir, job_type_file), 'r') as f:
+            job_file_yaml = yaml.safe_load(f.read())
+            job_meta = job_file_yaml['about']
+        job_types.append({'name': job_name,
+                          'about': job_meta})
+
+    return jsonify(job_types)

--- a/test/service/job/test_job_type_controller.py
+++ b/test/service/job/test_job_type_controller.py
@@ -28,7 +28,7 @@ class JobTypeTest(unittest.TestCase):
 
         response = self.client.get('/job_types')
 
-        self.assertEqual(len(job_types_from_files), len(json.loads(response.get_data(as_text=True))))
+        self.assertEqual(len(job_types_from_files), len(response.get_json()))
 
     def test_first_job_types_exists(self):
         """

--- a/test/service/job/test_job_type_controller.py
+++ b/test/service/job/test_job_type_controller.py
@@ -1,0 +1,43 @@
+import unittest
+import os
+
+from run_service import app
+
+from flask import json
+
+config_dir = os.environ['CONFIG_DIR']
+job_types_dir = os.path.join(config_dir, 'job_types')
+
+
+class JobTypeTest(unittest.TestCase):
+
+    def setUp(self):
+        app.testing = True
+        self.client = app.test_client()
+
+    def test_job_types_list_length(self):
+        """
+        Checks if the length of the element list of what the API returns is
+        the same than the number of files in the directory on disk.
+
+        :return: None
+        """
+        job_types_from_files = []
+        for job_type in os.listdir(job_types_dir):
+            job_types_from_files.append(job_type.rsplit('.', 1)[0])
+
+        response = self.client.get('/job_types')
+
+        self.assertEqual(len(job_types_from_files), len(json.loads(response.get_data(as_text=True))))
+
+    def test_first_job_types_exists(self):
+        """
+        Checks if the first filename from the job type directory is present
+        in the JSON returned by the API.
+
+        :return: None
+        """
+        first_job_type_name = os.listdir(job_types_dir)[0].rsplit('.', 1)[0]
+        response_text = self.client.get('/job_types').get_data(as_text=True)
+
+        self.assertIn(first_job_type_name, response_text)

--- a/test/service/job/test_job_type_controller.py
+++ b/test/service/job/test_job_type_controller.py
@@ -3,8 +3,6 @@ import os
 
 from run_service import app
 
-from flask import json
-
 config_dir = os.environ['CONFIG_DIR']
 job_types_dir = os.path.join(config_dir, 'job_types')
 


### PR DESCRIPTION
It serves a JSON list containing the job types found in the config dir.
From the job files the meta information, called 'about', is read and served
as well.

The tests check for the number of job types and if the first job type found
in the config dir is present.