### PR TITLE
Dtd validation

### DIFF
--- a/resources/ojs_template.xml
+++ b/resources/ojs_template.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE issues PUBLIC "-//PKP//OJS Articles and Issues XML//EN" "http://pkp.sfu.ca/ojs/dtds/2.4.8/native.dtd">
 <issues>
-    <issue identification="{{data['identification']}}" published="{{data['auto_publish_issue']}}">
+    <issue identification="{{data['identification']}}" published="{{data['auto_publish_issue']|lower}}">
+
+        {% if data['description'] %}
+        <description>{{data['description']}}</description>
+        {% endif %}
 
         {% if data['volume'] %}
         <volume>{{data['volume']}}</volume>
@@ -14,10 +18,6 @@
         {% if data['year'] %}
         <year>{{data['year']}}</year>
         {% endif -%}
-
-        {% if data['description'] %}
-        <description>{{data['description']}}</description>
-        {% endif %}
 
         <section>
             <title locale="en_US">Articles</title>

--- a/test/resources/objects/xml/ojs_import.xml
+++ b/test/resources/objects/xml/ojs_import.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE issues PUBLIC "-//PKP//OJS Articles and Issues XML//EN" "http://pkp.sfu.ca/ojs/dtds/2.4.8/native.dtd">
 <issues>
-    <issue identification="year" published="False">
+    <issue identification="year" published="false">
 
-        <year>2018</year>
         <description>[PDFs teilweise verfügbar]</description>
+        <year>2018</year>
 
         <section>
             <title locale="en_US">Articles</title>

--- a/test/worker/xml/test_validate_xml.py
+++ b/test/worker/xml/test_validate_xml.py
@@ -17,10 +17,14 @@ class ValidateXMLTest(unittest.TestCase):
         xml_file = self.ojs_xml_file
         validate_xml(xml_file)
 
+    def test_validate_xml_with_DTD(self):
+        xml_file = self.ojs_xml_file
+        validate_xml(xml_file, dtd_validation=True)
+
     def test_validate_xml_with_schema(self):
         xml_file = self.marc_xml_file
         xml_schema_file = self.marc_schema_file
-        validate_xml(xml_file, xml_schema_file)
+        validate_xml(xml_file, schema_file_path=xml_schema_file)
 
     def test_validation_failed_by_syntax(self):
         xml_file = self.ojs_xml_file_faulty
@@ -29,4 +33,4 @@ class ValidateXMLTest(unittest.TestCase):
     def test_validation_failed_by_schema(self):
         xml_file = self.marc_xml_file_faulty
         xml_schema_file = self.marc_schema_file
-        self.assertRaises(etree.DocumentInvalid, validate_xml, xml_file, xml_schema_file)
+        self.assertRaises(etree.DocumentInvalid, validate_xml, xml_file, schema_file_path=xml_schema_file)

--- a/workers/default/xml/tasks.py
+++ b/workers/default/xml/tasks.py
@@ -18,9 +18,11 @@ class GenerateMarcXMLTask(BaseTask):
         xml_template_string = _read_file(self.get_param('xml_template_path'))
         generate_marc_xml(work_path, data, xml_template_string)
 
+        marc_schema_file = 'resources/MARC21slim.xsd'
+
         for article_dir in os.listdir(os.path.join(work_path, 'articles')):
             file_path = os.path.join(work_path, 'articles', article_dir, 'marc.xml')
-            validate_xml(file_path)
+            validate_xml(file_path, schema_file_path=marc_schema_file)
 
 
 class GenerateXMLTask(BaseTask):
@@ -33,7 +35,7 @@ class GenerateXMLTask(BaseTask):
 
         generated_xml_file = generate_xml(work_path, data, xml_template_string)
 
-        validate_xml(generated_xml_file)
+        validate_xml(generated_xml_file, dtd_validation=True)
 
 
 GenerateMarcXMLTask = celery_app.register_task(GenerateMarcXMLTask())

--- a/workers/default/xml/xml_validator.py
+++ b/workers/default/xml/xml_validator.py
@@ -7,10 +7,16 @@ log = logging.getLogger(__name__)
 
 def validate_xml(xml_file_path, dtd_validation=False, schema_file_path=None):
     """
+    Validate XML for well-formed, XSD and DTD.
+
     Parses the given XML file. This throws syntax error if not well formed.
-    When the additional schema parameter s given it also checks the XML file
+    When the additional schema parameter is given it also checks the XML file
     against that.
+    When parameter is given also checks against the DTD referenced in the XML.
+    The DTD is downloaded from the web.
+
     :param str xml_file_path: path to XML file to be validated
+    :param bool dtd_validation: Switch to check against the referenced DTD
     :param str schema_file_path: (optional) path to XSD to be checked against
     :raises etree.XMLSyntaxError: if XML document is not well-formed
     :raises etree.DocumentInvalid: if XML document does not adhere to XSD
@@ -18,7 +24,7 @@ def validate_xml(xml_file_path, dtd_validation=False, schema_file_path=None):
     """
 
     if dtd_validation:
-        parser = etree.XMLParser(dtd_validation=True, no_network=False)  # TODO
+        parser = etree.XMLParser(dtd_validation=True, no_network=False)
     else:
         parser = etree.XMLParser()
 

--- a/workers/default/xml/xml_validator.py
+++ b/workers/default/xml/xml_validator.py
@@ -5,7 +5,7 @@ from lxml import etree
 log = logging.getLogger(__name__)
 
 
-def validate_xml(xml_file_path, schema_file_path=None):
+def validate_xml(xml_file_path, dtd_validation=False, schema_file_path=None):
     """
     Parses the given XML file. This throws syntax error if not well formed.
     When the additional schema parameter s given it also checks the XML file
@@ -16,7 +16,13 @@ def validate_xml(xml_file_path, schema_file_path=None):
     :raises etree.DocumentInvalid: if XML document does not adhere to XSD
     :return: None
     """
-    xml_doc = etree.parse(xml_file_path)
+
+    if dtd_validation:
+        parser = etree.XMLParser(dtd_validation=True, no_network=False)  # TODO
+    else:
+        parser = etree.XMLParser()
+
+    xml_doc = etree.parse(xml_file_path, parser)
     log.info("XML Syntax-Check OK!")
 
     if schema_file_path:


### PR DESCRIPTION
Die OJS XML wird gegen die referenzierte DTD gecheckt. Gibt einen neuen Schalter um das zu aktivieren.

Außerdem werden die generierten marcXMLs jetzt überhaupt erst validiert...^^
Nicht ganz optimal ist, dass der Pfad zu dem Schema hart verdratet ist. Da müssen wir mal schauen, dass wir da ein allgemeingültiges Resources-Verzeichnis definieren.