### PR TITLE
Cleanup after tests

### DIFF
--- a/test/integration/job_type_test.py
+++ b/test/integration/job_type_test.py
@@ -39,6 +39,14 @@ class JobTypeTest(unittest.TestCase):
         app.testing = True
         self.client = app.test_client()
 
+    def tearDown(self):
+        try:
+            shutil.rmtree(self.staging_dir)
+            shutil.rmtree(self.working_dir)
+            shutil.rmtree(self.repository_dir)
+        except OSError:
+            pass
+
     def assert_file_in_repository(self, object_id, file_path):
         waited = 0
         file = Path(os.path.join(self.repository_dir, object_id, file_path))

--- a/test/worker/convert/convert_test.py
+++ b/test/worker/convert/convert_test.py
@@ -16,13 +16,8 @@ class ConvertTest(unittest.TestCase):
     working_dir = "test_data"
 
     def setUp(self):
-        try:
-            os.makedirs(self.working_dir)
-        except OSError:
-            pass
+        os.makedirs(self.working_dir, exist_ok=True)
+
 
     def tearDown(self):
-        try:
-            shutil.rmtree(self.working_dir)
-        except OSError:
-            pass
+        shutil.rmtree(self.working_dir, ignore_errors=True)

--- a/test/worker/convert/convert_test.py
+++ b/test/worker/convert/convert_test.py
@@ -1,0 +1,28 @@
+import os
+import shutil
+import unittest
+
+
+class ConvertTest(unittest.TestCase):
+    """
+    Base class for conversion tests
+
+    Ensures the test working dir is created before and removed after each test.
+
+    Make sure to explicitly call super().setUp() and super().tearDown() if
+    you need to extend these methods.
+    """
+    resource_dir = os.environ['RESOURCE_DIR']
+    working_dir = "test_data"
+
+    def setUp(self):
+        try:
+            os.makedirs(self.working_dir)
+        except OSError:
+            pass
+
+    def tearDown(self):
+        try:
+            shutil.rmtree(self.working_dir)
+        except OSError:
+            pass

--- a/test/worker/convert/test_cut_pdf.py
+++ b/test/worker/convert/test_cut_pdf.py
@@ -1,38 +1,32 @@
 import shutil
 import os
-import unittest
 import logging
 
+from test.worker.convert.convert_test import ConvertTest
 from workers.convert.image_pdf.convert_pdf import cut_pdf
 
 log = logging.getLogger(__name__)
 
 
-class CutPdfTest(unittest.TestCase):
-    resource_dir = os.environ['RESOURCE_DIR']
-    working_dir = os.environ['WORKING_DIR']
-    pdf_src = f'{resource_dir}/files/test.pdf'
-    files_generated = [
-        f'{working_dir}/test.pdf',
-        f'{working_dir}/test.pdf.0.pdf',
-        f'{working_dir}/test.pdf.1.pdf'
-    ]
-    source_path = working_dir
-    target_path = source_path
+class CutPdfTest(ConvertTest):
 
     def setUp(self):
+        super().setUp()
+
+        self.pdf_src = f'{self.resource_dir}/files/test.pdf'
+        self.files_generated = [
+            f'{self.working_dir}/test.pdf',
+            f'{self.working_dir}/test.pdf.0.pdf',
+            f'{self.working_dir}/test.pdf.1.pdf'
+        ]
+
         shutil.copy(self.pdf_src, self.files_generated[0])
 
     def test_success(self):
-        params = [{"file": "test.pdf", "range": [1, 20]}, {"file": "test.pdf", "range": [21, 27]}]
-        cut_pdf(params, self.source_path, self.target_path)
+        params = [
+            {"file": "test.pdf", "range": [1, 20]},
+            {"file": "test.pdf", "range": [21, 27]}
+        ]
+        cut_pdf(params, self.working_dir, self.working_dir)
         for file_generated in self.files_generated:
             self.assertTrue(os.path.isfile(file_generated))
-
-    def tearDown(self):
-        for file_generated in self.files_generated:
-            try:
-                os.remove(file_generated)
-                log.debug("Deleted file: " + file_generated)
-            except FileNotFoundError as e:
-                log.error("File not found: " + e.filename)

--- a/test/worker/convert/test_jpg_to_pdf.py
+++ b/test/worker/convert/test_jpg_to_pdf.py
@@ -1,44 +1,18 @@
 import os
-import unittest
 
-from workers.convert.image_pdf.convert_pdf import pdf_merge
+from test.worker.convert.convert_test import ConvertTest
 from workers.convert.image_pdf.convert_image_pdf import convert_jpg_to_pdf
 
 
-class Jpg2PdfTest(unittest.TestCase):
-    resource_dir = os.environ['RESOURCE_DIR']
-    working_dir = os.environ['WORKING_DIR']
-    jpg_0_src = f'{resource_dir}/files/test.jpg'
-    generated_file = f'{working_dir}/test.pdf'
+class Jpg2PdfTest(ConvertTest):
+
+    def setUp(self):
+        super().setUp()
+        self.jpg_0_src = f'{self.resource_dir}/files/test.jpg'
+        self.generated_file = f'{self.working_dir}/test.pdf'
 
     def test_success(self):
         convert_jpg_to_pdf(self.jpg_0_src, self.generated_file)
         self.assertTrue(os.path.isfile(self.generated_file))
         stat = os.stat(self.generated_file)
         self.assertGreater(stat.st_size, 0)
-
-    def tearDown(self):
-        try:
-            os.remove(self.generated_file)
-        except FileNotFoundError:
-            pass
-
-
-class MergeConvertedPdfTest(unittest.TestCase):
-    resource_dir = os.environ['RESOURCE_DIR']
-    working_dir = os.environ['WORKING_DIR']
-    pdf_1 = f'{resource_dir}/files/test.pdf'
-    pdf_2 = f'{resource_dir}/files/test.pdf'
-    generated_file = f'{working_dir}/merged.pdf'
-
-    def test_success(self):
-        pdf_merge([self.pdf_1, self.pdf_2], self.generated_file)
-        self.assertTrue(os.path.isfile(self.generated_file))
-        stat = os.stat(self.generated_file)
-        self.assertGreater(stat.st_size, 0)
-
-    def tearDown(self):
-        try:
-            os.remove(self.generated_file)
-        except FileNotFoundError:
-            pass

--- a/test/worker/convert/test_merge_pdf.py
+++ b/test/worker/convert/test_merge_pdf.py
@@ -1,0 +1,19 @@
+import os
+
+from workers.convert.image_pdf.convert_pdf import merge_pdf
+from test.worker.convert.convert_test import ConvertTest
+
+
+class MergePdfTest(ConvertTest):
+
+    def setUp(self):
+        super().setUp()
+        self.pdf_1 = f'{self.resource_dir}/files/test.pdf'
+        self.pdf_2 = f'{self.resource_dir}/files/test.pdf'
+        self.generated_file = f'{self.working_dir}/merged.pdf'
+
+    def test_success(self):
+        merge_pdf([self.pdf_1, self.pdf_2], self.generated_file)
+        self.assertTrue(os.path.isfile(self.generated_file))
+        stat = os.stat(self.generated_file)
+        self.assertGreater(stat.st_size, 0)

--- a/test/worker/convert/test_pdf_to_tif.py
+++ b/test/worker/convert/test_pdf_to_tif.py
@@ -1,28 +1,20 @@
 import os
 import shutil
 
-import unittest
 from pathlib import Path
 
+from test.worker.convert.convert_test import ConvertTest
 from workers.convert.image_pdf.convert_image_pdf import convert_pdf_to_tif
 
 
-class PdfToTifTest(unittest.TestCase):
-    resource_dir = os.environ['RESOURCE_DIR']
-    working_dir = os.environ['WORKING_DIR']
-    pdf_src = f'{resource_dir}/files/test_small.pdf'
-    pdf_path = f'{working_dir}/test.pdf'
-    tif_path = '{}/{}.tif'
+class PdfToTifTest(ConvertTest):
 
     def setUp(self):
+        super().setUp()
+        self.pdf_src = f'{self.resource_dir}/files/test_small.pdf'
+        self.pdf_path = f'{self.working_dir}/test.pdf'
+        self.tif_path = '{}/{}.tif'
         shutil.copy(self.pdf_src, self.pdf_path)
-
-    def tearDown(self):
-        for i in range(0, 27):
-            try:
-                os.remove(self.tif_path.format(self.working_dir, i))
-            except FileNotFoundError:
-                pass
 
     def test_success(self):
         convert_pdf_to_tif(self.pdf_path, self.working_dir)

--- a/test/worker/convert/test_pdf_to_txt.py
+++ b/test/worker/convert/test_pdf_to_txt.py
@@ -1,24 +1,17 @@
 import os
-import shutil
-import unittest
 
+from test.worker.convert.convert_test import ConvertTest
 from workers.convert.image_pdf.convert_pdf import convert_pdf_to_txt
 
 
-class PdfToTxtTest(unittest.TestCase):
-
-    resource_dir = os.environ['RESOURCE_DIR']
-    working_dir = os.environ['WORKING_DIR']
-    txt_dir = os.path.join(working_dir, 'txt_from_pdf')
-
-    pdf_path = f'{resource_dir}/files/test.pdf'
-    pdf_pages = 27
+class PdfToTxtTest(ConvertTest):
 
     def setUp(self):
+        super().setUp()
+        self.txt_dir = os.path.join(self.working_dir, 'txt_from_pdf')
+        self.pdf_path = f'{self.resource_dir}/files/test.pdf'
+        self.pdf_pages = 27
         os.makedirs(self.txt_dir)
-
-    def tearDown(self):
-        shutil.rmtree(self.txt_dir)
 
     def test_success(self):
         convert_pdf_to_txt(self.pdf_path, self.txt_dir)

--- a/test/worker/convert/test_tif_to_jpg.py
+++ b/test/worker/convert/test_tif_to_jpg.py
@@ -1,19 +1,20 @@
 import os
-import unittest
 import logging
 from pathlib import Path
 
+from test.worker.convert.convert_test import ConvertTest
 from workers.convert.image_pdf.convert_image import convert_tif_to_jpg
 
 log = logging.getLogger(__name__)
 
 
-class TifToJpgTest(unittest.TestCase):
-    resource_dir = os.environ['RESOURCE_DIR']
-    working_dir = os.environ['WORKING_DIR']
-    tif_path = f'{resource_dir}/files/test.tif'
-    broken_tif_path = f'{resource_dir}/files/broken.tif'
-    jpg_path = f'{working_dir}/test.jpg'
+class TifToJpgTest(ConvertTest):
+
+    def setUp(self):
+        super().setUp()
+        self.tif_path = f'{self.resource_dir}/files/test.tif'
+        self.broken_tif_path = f'{self.resource_dir}/files/broken.tif'
+        self.jpg_path = f'{self.working_dir}/test.jpg'
 
     def test_success(self):
         convert_tif_to_jpg(self.tif_path, self.jpg_path)
@@ -23,11 +24,3 @@ class TifToJpgTest(unittest.TestCase):
 
     def test_error(self):
         self.assertRaises(OSError, convert_tif_to_jpg, self.broken_tif_path, self.jpg_path)
-
-    @classmethod
-    def tearDownClass(cls):
-        try:
-            os.remove(cls.jpg_path)
-            log.debug("Deleted file: " + cls.jpg_path)
-        except FileNotFoundError as e:
-            log.error("File not found: " + e.filename)

--- a/workers/convert/image_pdf/convert_pdf.py
+++ b/workers/convert/image_pdf/convert_pdf.py
@@ -20,7 +20,7 @@ def convert_pdf_to_txt(source_file, output_dir):
             index += 1
 
 
-def pdf_merge(file_paths, output_path):
+def merge_pdf(file_paths, output_path):
     """
     Create a single pdf from multiple ones merged together
 

--- a/workers/convert/image_pdf/tasks.py
+++ b/workers/convert/image_pdf/tasks.py
@@ -6,7 +6,7 @@ from workers.base_task import BaseTask
 
 from workers.convert.image_pdf.convert_image import convert_tif_to_jpg
 from workers.convert.image_pdf.convert_pdf import convert_pdf_to_txt, \
-    pdf_merge, cut_pdf
+    merge_pdf, cut_pdf
 from workers.convert.image_pdf.convert_image_pdf import convert_pdf_to_tif, \
     convert_jpg_to_pdf
 
@@ -69,7 +69,7 @@ class MergeConvertedPdf(BaseTask):
     def execute_task(self):
         work_path = self.get_work_path()
         files = _list_files(work_path, '.converted.pdf')
-        pdf_merge(files, work_path + '/merged.pdf')
+        merge_pdf(files, work_path + '/merged.pdf')
         # TODO incorporate JSON data for the filename and metadatas.
 
 


### PR DESCRIPTION
This removes the staging, working and repository folders after each
integration test.

All tests in the convert module now inherit from a common base class
that ensures a clean test working directory is created before and
removed after every single test.