### PR TITLE
Controller error handling

### DIFF
--- a/run_service.py
+++ b/run_service.py
@@ -30,7 +30,7 @@ app.register_blueprint(user_controller, url_prefix="/user")
 @app.errorhandler(ApiError)
 def handle_api_error(error):
     """
-    Handles custom ApiErrors raised in controllers.
+    Handle custom ApiErrors raised in controllers.
 
     This makes sure that a response object following a common JSON syntax
     is returned.
@@ -46,7 +46,7 @@ def handle_api_error(error):
 @app.errorhandler(HTTPException)
 def handle_http_exception(error):
     """
-    Handles exceptions raised by flask internally.
+    Handle exceptions raised by flask internally.
 
     This makes sure that a response object following a common JSON syntax
     is returned.

--- a/run_service.py
+++ b/run_service.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from flask import Flask
+from flask import Flask, jsonify
 from flask_cors import CORS
 
 from utils.setup_logging import setup_logging
@@ -9,6 +9,7 @@ from service.job.job_type_controller import job_type_controller
 from service.staging.staging_controller import staging_controller
 from service.repository.repository_controller import repository_controller
 from service.user.user_controller import user_controller
+from service.errors import ApiError
 
 setup_logging()
 
@@ -21,3 +22,10 @@ app.register_blueprint(job_type_controller, url_prefix="/job_types")
 app.register_blueprint(staging_controller, url_prefix="/staging")
 app.register_blueprint(repository_controller, url_prefix="/repository")
 app.register_blueprint(user_controller, url_prefix="/user")
+
+
+@app.errorhandler(ApiError)
+def handle_invalid_usage(error):
+    response = jsonify(error.to_dict())
+    response.status_code = error.status_code
+    return response

--- a/service/errors.py
+++ b/service/errors.py
@@ -1,0 +1,15 @@
+class ApiError(Exception):
+    status_code = 400
+
+    def __init__(self, message, status_code=None, payload=None):
+        Exception.__init__(self)
+        self.message = message
+        if status_code is not None:
+            self.status_code = status_code
+        self.payload = payload
+
+    def to_dict(self):
+        dic = dict(self.payload or ())
+        dic['success'] = False
+        dic['message'] = self.message
+        return dic

--- a/service/errors.py
+++ b/service/errors.py
@@ -1,8 +1,9 @@
 class ApiError(Exception):
     status_code = 400
 
-    def __init__(self, message, status_code=None, payload=None):
+    def __init__(self, error_code, message, status_code=None, payload=None):
         Exception.__init__(self)
+        self.error_code = error_code
         self.message = message
         if status_code is not None:
             self.status_code = status_code
@@ -11,5 +12,8 @@ class ApiError(Exception):
     def to_dict(self):
         dic = dict(self.payload or ())
         dic['success'] = False
-        dic['message'] = self.message
+        dic['error'] = {
+            "code": self.error_code,
+            "message": self.message
+        }
         return dic

--- a/service/job/job_controller.py
+++ b/service/job/job_controller.py
@@ -42,7 +42,9 @@ def job_create(job_type):
     :return: A JSON object containing the status, the job id and the task ids
         of every subtask in the chain
     """
-    params = request.get_json(force=True)
+    params = {}
+    if request.data:
+        params = request.get_json(force=True)
     user = auth.username()
     try:
         job = get_job_config().generate_job(job_type, user, params)

--- a/service/job/job_type_controller.py
+++ b/service/job/job_type_controller.py
@@ -1,7 +1,9 @@
 import os
 import yaml
 
-from flask import Blueprint, jsonify, abort
+from flask import Blueprint, jsonify
+
+from service.errors import ApiError
 
 job_type_controller = Blueprint('job_types', __name__)
 
@@ -41,4 +43,4 @@ def get_job_type_detail(job_type):
         with open(os.path.join(job_types_dir, job_type) + '.yml', 'r') as f:
             return jsonify(yaml.safe_load(f.read()))
     except FileNotFoundError:
-        abort(404)
+        raise ApiError("Job type not found", 404)

--- a/service/job/job_type_controller.py
+++ b/service/job/job_type_controller.py
@@ -43,4 +43,8 @@ def get_job_type_detail(job_type):
         with open(os.path.join(job_types_dir, job_type) + '.yml', 'r') as f:
             return jsonify(yaml.safe_load(f.read()))
     except FileNotFoundError:
-        raise ApiError("Job type not found", 404)
+        raise ApiError(
+            "job_type_not_found",
+            f"No definition for given job type '{job_type}' found",
+            404
+        )

--- a/service/repository/repository_controller.py
+++ b/service/repository/repository_controller.py
@@ -2,6 +2,7 @@ import os
 
 from flask import Blueprint, jsonify, send_file, abort
 
+from service.errors import ApiError
 
 repository_controller = Blueprint('repository', __name__)
 
@@ -25,4 +26,5 @@ def get_path(path):
     elif os.path.isfile(abs_path):
         return send_file(abs_path)
     else:
-        abort(404)
+        raise ApiError("file_not_found",
+                       f"No resource was found under the path {path}", 404)

--- a/test/resources/configs/config_valid/job_types/job1.yml
+++ b/test/resources/configs/config_valid/job_types/job1.yml
@@ -1,3 +1,6 @@
+params:
+  do_task2: boolean
+
 tasks:
   - retrieve
   - foreach: "*.tif"

--- a/test/service/job/test_job_controller.py
+++ b/test/service/job/test_job_controller.py
@@ -4,7 +4,7 @@ from run_service import app
 from test.service.user.user_utils import get_auth_header
 
 
-class JobTest(unittest.TestCase):
+class JobControllerTest(unittest.TestCase):
 
     def setUp(self):
         app.testing = True

--- a/test/service/job/test_job_controller.py
+++ b/test/service/job/test_job_controller.py
@@ -22,6 +22,11 @@ class JobTest(unittest.TestCase):
                                     headers=get_auth_header())
         self.assertEqual(response.status_code, 400)
 
+        response_json = response.get_json()
+        print(f"RESPONSE: {response_json}")
+        self.assertFalse(response_json['success'])
+        self.assertEqual(response_json['error']['code'], "bad_request")
+
     def test_create_job_unknown_param(self):
         response = self.client.post('/job/ingest_journal', data='{"asd": true}',
                                     headers=get_auth_header())

--- a/test/service/job/test_job_controller.py
+++ b/test/service/job/test_job_controller.py
@@ -1,0 +1,51 @@
+import unittest
+
+from run_service import app
+from test.service.user.user_utils import get_auth_header
+
+
+class JobTest(unittest.TestCase):
+
+    def setUp(self):
+        app.testing = True
+        self.client = app.test_client()
+
+    def test_create_job_success(self):
+        response = self.client.post('/job/ingest_journal',
+                                    headers=get_auth_header())
+        self.assertEqual(response.status_code, 202)
+        response_json = response.get_json()
+        self.assertEqual(response_json['status'], 'Accepted')
+
+    def test_create_job_invalid_json(self):
+        response = self.client.post('/job/ingest_journal', data="jkhsadfj,';",
+                                    headers=get_auth_header())
+        self.assertEqual(response.status_code, 400)
+
+    def test_create_job_unknown_param(self):
+        response = self.client.post('/job/ingest_journal', data='{"asd": true}',
+                                    headers=get_auth_header())
+        self.assertEqual(response.status_code, 400)
+
+        response_json = response.get_json()
+        self.assertFalse(response_json['success'])
+        self.assertEqual(response_json['error']['code'], "invalid_job_params")
+
+    def test_create_job_invalid_params(self):
+        response = self.client.post('/job/ingest_journal',
+                                    data='{"split_files": true}',
+                                    headers=get_auth_header())
+        self.assertEqual(response.status_code, 400)
+
+        response_json = response.get_json()
+        self.assertFalse(response_json['success'])
+        self.assertEqual(response_json['error']['code'], "invalid_job_params")
+
+    def test_create_job_invalid_job_type(self):
+        response = self.client.post('/job/foobarbaz',
+                                    headers=get_auth_header())
+        self.assertEqual(response.status_code, 404)
+
+        response_json = response.get_json()
+        self.assertFalse(response_json['success'])
+        self.assertEqual(response_json['error']['code'], "unknown_job_type")

--- a/test/service/job/test_job_controller.py
+++ b/test/service/job/test_job_controller.py
@@ -23,7 +23,6 @@ class JobControllerTest(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
 
         response_json = response.get_json()
-        print(f"RESPONSE: {response_json}")
         self.assertFalse(response_json['success'])
         self.assertEqual(response_json['error']['code'], "bad_request")
 

--- a/test/service/job/test_job_controller.py
+++ b/test/service/job/test_job_controller.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 
 from run_service import app
@@ -9,16 +10,17 @@ class JobControllerTest(unittest.TestCase):
     def setUp(self):
         app.testing = True
         self.client = app.test_client()
+        os.environ['CONFIG_DIR'] = "test/resources/configs/config_valid"
 
     def test_create_job_success(self):
-        response = self.client.post('/job/ingest_journal',
+        response = self.client.post('/job/job1',
                                     headers=get_auth_header())
         self.assertEqual(response.status_code, 202)
         response_json = response.get_json()
         self.assertEqual(response_json['status'], 'Accepted')
 
     def test_create_job_invalid_json(self):
-        response = self.client.post('/job/ingest_journal', data="jkhsadfj,';",
+        response = self.client.post('/job/job1', data="jkhsadfj,';",
                                     headers=get_auth_header())
         self.assertEqual(response.status_code, 400)
 
@@ -27,7 +29,7 @@ class JobControllerTest(unittest.TestCase):
         self.assertEqual(response_json['error']['code'], "bad_request")
 
     def test_create_job_unknown_param(self):
-        response = self.client.post('/job/ingest_journal', data='{"asd": true}',
+        response = self.client.post('/job/job1', data='{"asd": true}',
                                     headers=get_auth_header())
         self.assertEqual(response.status_code, 400)
 
@@ -36,8 +38,8 @@ class JobControllerTest(unittest.TestCase):
         self.assertEqual(response_json['error']['code'], "invalid_job_params")
 
     def test_create_job_invalid_params(self):
-        response = self.client.post('/job/ingest_journal',
-                                    data='{"split_files": true}',
+        response = self.client.post('/job/job1',
+                                    data='{"do_task2": "blabla"}',
                                     headers=get_auth_header())
         self.assertEqual(response.status_code, 400)
 

--- a/test/service/job/test_job_type_controller.py
+++ b/test/service/job/test_job_type_controller.py
@@ -74,3 +74,4 @@ class JobTypeTest(unittest.TestCase):
 
         response_json = response.get_json()
         self.assertFalse(response_json['success'])
+        self.assertEqual(response_json['error']['code'], "job_type_not_found")

--- a/test/service/job/test_job_type_controller.py
+++ b/test/service/job/test_job_type_controller.py
@@ -67,3 +67,10 @@ class JobTypeTest(unittest.TestCase):
         response_text = self.client.get('/job_types/' + first_job_type_file.rsplit('.', 1)[0]).get_data(as_text=True)
 
         self.assertEqual(yaml.safe_load(first_job_type_file_content), yaml.safe_load(str(response_text)))
+
+    def test_invalid_job_type(self):
+        response = self.client.get('/job_types/foobarbaz')
+        self.assertEqual(404, response.status_code)
+
+        response_json = response.get_json()
+        self.assertFalse(response_json['success'])

--- a/test/service/job/test_job_type_controller.py
+++ b/test/service/job/test_job_type_controller.py
@@ -9,7 +9,7 @@ config_dir = os.environ['CONFIG_DIR']
 job_types_dir = os.path.join(config_dir, 'job_types')
 
 
-class JobTypeTest(unittest.TestCase):
+class JobTypeControllerTest(unittest.TestCase):
 
     def setUp(self):
         app.testing = True

--- a/test/service/repository/test_repository_controller.py
+++ b/test/service/repository/test_repository_controller.py
@@ -51,3 +51,7 @@ class RepositoryControllerTest(unittest.TestCase):
     def test_get_file_not_found(self):
         response = self.client.get(f'/repository/{test_object}/not_{test_file}')
         self.assertEqual(response.status_code, 404)
+
+        response_json = response.get_json()
+        self.assertFalse(response_json['success'])
+        self.assertEqual(response_json['error']['code'], "file_not_found")


### PR DESCRIPTION
Introduce error class for controller exceptions.

Uses flask error handling to catch exceptions and serialize them to
a unified JSON format.

Instead of using abort(status) controllers now should use
raise ApiError(message, status) to trigger API usage errors.