### PR TITLE
Move split_pdf into create_object, while split now works with abs path.

### DIFF
--- a/config/job_types/ingest_journal.yml
+++ b/config/job_types/ingest_journal.yml
@@ -17,7 +17,6 @@ params:
 
 tasks:
   - create_object
-  - convert.split_pdf
   - foreach: ".*\\.pdf$"
     do: convert.pdf_to_tif
   - task: convert.tif_to_txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
 
   default-worker:
     user: ${UID}
-    image: dainst/cilantro-default-worker:stable
+    image: dainst/cilantro-default-worker:test_pdf
     volumes:
       - .:/app
       - ./data:/data

--- a/test/worker/convert/test_cut_pdf.py
+++ b/test/worker/convert/test_cut_pdf.py
@@ -16,9 +16,9 @@ class CutPdfTest(ConvertTest):
     file_generated = f'{working_dir}/data/pdf/merged.pdf'
 
     def test_success(self):
-        params = [{"file": "e2e-testing.pdf", "range": [1, 20]},
-                  {"file": "e2e-testing.pdf", "range": [21, 27]}]
         obj = Object(self.working_dir)
+        params = [{"file": f"{obj.get_representation_dir('pdf')}/e2e-testing.pdf", "range": [1, 20]},
+                  {"file": f"{obj.get_representation_dir('pdf')}/e2e-testing.pdf", "range": [21, 27]}]
         stream = open(self.pdf_src, 'rb')
         obj.add_stream('e2e-testing.pdf', 'pdf', stream)
         stream.close()

--- a/workers/convert/convert_pdf.py
+++ b/workers/convert/convert_pdf.py
@@ -30,14 +30,15 @@ def split_merge_pdf(files, path: str, filename='merged.pdf', remove_old=True):
 
     :param list files: list of the source pdf files as dict in the format:
         {'file': relative_path, 'range': [start, end]}
-    :param string path: The path where the used files lie the created file go
+    :param string path: The path to the dir where the created file go
     :param string filename: name of the generated pdf file.
     :param bool remove_old: if True, removes the files used for the split/merge.
     """
-
+    if not os.path.exists(path):
+        os.makedirs(path)
     new_pdf = PyPDF2.PdfFileWriter()
     for file in files:
-        input_str = os.path.join(path, file['file'])
+        input_str = file['file']
         input_stream = open(input_str, 'rb')
         pdf = PyPDF2.PdfFileReader(input_stream)
         if pdf.flattenedPages is None:

--- a/workers/convert/convert_pdf.py
+++ b/workers/convert/convert_pdf.py
@@ -34,8 +34,7 @@ def split_merge_pdf(files, path: str, filename='merged.pdf', remove_old=True):
     :param string filename: name of the generated pdf file.
     :param bool remove_old: if True, removes the files used for the split/merge.
     """
-    if not os.path.exists(path):
-        os.makedirs(path)
+    os.makedirs(path, exist_ok=True)
     new_pdf = PyPDF2.PdfFileWriter()
     for file in files:
         input_str = file['file']

--- a/workers/default/repository/tasks.py
+++ b/workers/default/repository/tasks.py
@@ -1,10 +1,10 @@
 import os
 import shutil
-from pathlib import Path
 
 from utils.celery_client import celery_app
 from workers.base_task import BaseTask
 from utils.object import Object
+from workers.convert.convert_pdf import split_merge_pdf
 
 repository_dir = os.environ['REPOSITORY_DIR']
 working_dir = os.environ['WORKING_DIR']
@@ -12,6 +12,22 @@ staging_dir = os.environ['STAGING_DIR']
 
 
 class CreateObjectTask(BaseTask):
+    """
+    Create a Cilantro-Object, the metadatas and the data files in it.
+    Split and merge pdf given files.
+
+    TaskParams:
+    -str user: user ID
+    -dic metadata: The metadata of the object
+    -list files: the file informations for the object
+    -list parts: the list of the subchild objects of the object.
+
+    Preconditions:
+    -files in staging
+
+    Creates:
+    -An Object in the working dir
+    """
     name = "create_object"
 
     def execute_task(self):
@@ -19,7 +35,7 @@ class CreateObjectTask(BaseTask):
         obj = Object(self.get_work_path())
         obj.set_metadata_from_dict(self.get_param('metadata'))
         files = self.get_param('files')
-        self._add_files(obj, files, user)
+        _add_files(obj, files, user)
         if 'parts' in self.params:
             self._execute_for_parts(obj, self.get_param('parts'), user)
 
@@ -29,19 +45,29 @@ class CreateObjectTask(BaseTask):
             child.set_metadata_from_dict(part['metadata'])
 
             if 'files' in part:
-                self._add_files(child, part['files'], user)
+                _add_files(child, part['files'], user)
 
             if 'parts' in part:
                 self._execute_for_parts(child, part['parts'], user)
 
-    @staticmethod
-    def _add_files(obj, files, user):
-        for file in files:
-            src = os.path.join(staging_dir, user, file['file'])
-            obj.add_file(Object.INITIAL_REPRESENTATION, src)
-
 
 CreateObjectTask = celery_app.register_task(CreateObjectTask())
+
+
+def _add_files(obj, files, user):
+    pdf_files = []
+    for file in files:
+        suffix = (file['file']).split('.')[-1]
+
+        src = os.path.join(staging_dir, user, file['file'])
+        if suffix == 'pdf':
+            pdf_files.append({'file': src, 'range': file['range']})
+        else:
+            obj.add_file(Object.INITIAL_REPRESENTATION, src)
+
+    if len(pdf_files) > 0:
+        rep_dir = obj.get_representation_dir(Object.INITIAL_REPRESENTATION)
+        split_merge_pdf(pdf_files, rep_dir)
 
 
 class PublishToRepositoryTask(BaseTask):


### PR DESCRIPTION
Default worker now needs pdf imports as a result (change image-tag to
test_pdf).