### PR TITLE
Job results

### DIFF
--- a/service/job/job_config.py
+++ b/service/job/job_config.py
@@ -144,7 +144,7 @@ def _create_foreach_signature(task_def, params):
     kwargs = params.copy()
     kwargs['pattern'] = task_def['pattern']
     kwargs['subtasks'] = task_def['do']
-    return celery_app.signature('foreach', kwargs=kwargs, immutable=True)
+    return celery_app.signature('foreach', kwargs=kwargs)
 
 
 def _create_if_signature(task_def, params):
@@ -167,7 +167,7 @@ def _create_signature_for_task(task_def, params=None):
         kwargs.update(task_def['params'])
     if params:
         kwargs.update(params)
-    return celery_app.signature(task_def['name'], kwargs=kwargs, immutable=True)
+    return celery_app.signature(task_def['name'], kwargs=kwargs)
 
 
 def _init_default_params(params):

--- a/service/job/job_controller.py
+++ b/service/job/job_controller.py
@@ -80,8 +80,8 @@ def job_status(job_id):
     response = {
         'status': task.state
     }
-    if hasattr(task.info, 'result'):
-        response['result'] = task.info['result']
+    if hasattr(task, 'result'):
+        response['result'] = task.result
     return jsonify(response)
 
 

--- a/workers/base_task.py
+++ b/workers/base_task.py
@@ -72,7 +72,7 @@ class BaseTask(Task):
 
     def run(self, prev_result=None, **params):
         self._init_params(params)
-        if type(prev_result) is list:
+        if isinstance(prev_result, list):
             for result in prev_result:
                 self.params['result'] = self._add_result_to_params(result)
         else:
@@ -107,7 +107,7 @@ class BaseTask(Task):
         raise NotImplementedError("Execute Task method not implemented")
 
     def _add_result_to_params(self, result):
-        if type(result) is dict:
+        if isinstance(result, dict):
             return merge_dicts(self.params['result'], result)
         elif result:
             raise KeyError(f"Wrong result type in previous task")

--- a/workers/base_task.py
+++ b/workers/base_task.py
@@ -23,7 +23,10 @@ def on_celery_setup_logging(**_):
 
 def merge_dicts(a, b, path=None):
     """
-    Merge two dictionaries.
+    Deep merge two dictionaries.
+    
+    The two dictionaries are merged recursively so that values
+    that are themselves dictionaries are merged as well.
 
     :param dict a:
     :param dict b:

--- a/workers/base_task.py
+++ b/workers/base_task.py
@@ -22,8 +22,16 @@ def on_celery_setup_logging(**_):
 
 
 def merge_dicts(a, b, path=None):
-    "merges b into a"
-    if path is None: path = []
+    """
+    Merge two dictionaries.
+
+    :param dict a:
+    :param dict b:
+    :param str path:
+    :return dict:
+    """
+    if path is None:
+        path = []
     for key in b:
         if key in a:
             if isinstance(a[key], dict) and isinstance(b[key], dict):
@@ -45,6 +53,10 @@ class BaseTask(Task):
     the file system.
 
     Implementations should override the execute_task() method.
+
+    Return values of execute_task() are saved under the 'result' key in the
+    params dictionary. This allows reading task results at a later stage,
+    i.e. in a following task or when querying the job status.
     """
 
     working_dir = os.environ['WORKING_DIR']
@@ -85,7 +97,12 @@ class BaseTask(Task):
 
         This method has to be implemented by all subclassed tasks and includes
         the actual implementation logic of the specific task.
-        :return:
+
+        Results have to be dicts and are merged recursively so that partial
+        results in task chains accumulate and may be extended or modified
+        by following tasks.
+
+        :return dict:
         """
         raise NotImplementedError("Execute Task method not implemented")
 

--- a/workers/base_task.py
+++ b/workers/base_task.py
@@ -24,7 +24,7 @@ def on_celery_setup_logging(**_):
 def merge_dicts(a, b, path=None):
     """
     Deep merge two dictionaries.
-    
+
     The two dictionaries are merged recursively so that values
     that are themselves dictionaries are merged as well.
 


### PR DESCRIPTION
Return values of tasks are now saved under the 'result' key in the
params dictionary. This allows reading task results at a later stage,
i.e. in a following task or when querying the job status.

Results have to be dicts and are merged recursively so that partial
results in task chains accumulate and may be extended or modified
by following tasks.

Accumulated results are returned by the job status endpoint.

See http://dai-softsource.uni-koeln.de/issues/9109