### PR TITLE
Manage object id

### DIFF
--- a/config/job_types/ingest_book.yml
+++ b/config/job_types/ingest_book.yml
@@ -6,6 +6,7 @@ about:
 params:
   files: list
   metadata: dict
+  object_id: string
 
 tasks:
   - create_object

--- a/test/integration/job_type_test.py
+++ b/test/integration/job_type_test.py
@@ -61,7 +61,7 @@ class JobTypeTest(unittest.TestCase):
         success = False
         while not success:
             for task_id in task_ids:
-                status = self.get_status(task_id)
+                status = self.get_status(task_id)['status']
                 if status == 'FAILURE':
                     raise AssertionError("child task in FAILURE state")
                 elif status == 'SUCCESS':
@@ -86,12 +86,11 @@ class JobTypeTest(unittest.TestCase):
                 raise AssertionError(f"experienced timeout while waiting for "
                                      f"status '{expected_status}', last status "
                                      f"was '{status}'")
-            status = self.get_status(job_id)
+            status = self.get_status(job_id)['status']
 
     def get_status(self, job_id):
         response = self.client.get(f'/job/{job_id}')
-        data = json.loads(response.get_data(as_text=True))
-        return data['status']
+        return json.loads(response.get_data(as_text=True))
 
     def post_job(self, job_type, data):
         response = self.client.post(

--- a/test/integration/job_type_test.py
+++ b/test/integration/job_type_test.py
@@ -45,6 +45,15 @@ class JobTypeTest(unittest.TestCase):
 
     def assert_file_in_repository(self, object_id, file_path,
                                   wait_time=default_wait_time):
+        """
+        Assert that a file is present in the repository.
+
+        :param str object_id:
+        :param str file_path:
+        :param int wait_time: Time in ms to wait for the file to appear
+            before failing
+        :return:
+        """
         waited = 0
         file = Path(os.path.join(self.repository_dir, object_id, file_path))
         while not file.is_file():
@@ -57,6 +66,16 @@ class JobTypeTest(unittest.TestCase):
                 time.sleep(0.001 * retry_time)
 
     def assert_job_successful(self, task_ids, wait_time=default_wait_time):
+        """
+        Assert that a job completed successfully.
+
+        Fails if one of the tasks given is in failure state or when wait time
+        is reached.
+
+        :param str task_ids:
+        :param int wait_time: Time in ms to wait before failing
+        :return:
+        """
         waited = 0
         success = False
         while not success:
@@ -77,6 +96,14 @@ class JobTypeTest(unittest.TestCase):
 
     def assert_status(self, job_id, expected_status,
                       wait_time=default_wait_time):
+        """
+        Assert that a job has a certain status.
+
+        :param str job_id:
+        :param str expected_status:
+        :param int wait_time: Time in ms to wait before failing
+        :return:
+        """
         waited = 0
         status = self.get_status(job_id)
         while status != expected_status:
@@ -89,10 +116,28 @@ class JobTypeTest(unittest.TestCase):
             status = self.get_status(job_id)['status']
 
     def get_status(self, job_id):
+        """
+        Get the job status.
+
+        This includes the status string and an optional result object.
+
+        :param str job_id:
+        :return dict:
+        """
         response = self.client.get(f'/job/{job_id}')
         return json.loads(response.get_data(as_text=True))
 
     def post_job(self, job_type, data):
+        """
+        Create a new job.
+
+        The result object contains the job_id for the new job that can be used
+        to query the status and result.
+
+        :param str job_type:
+        :param data: Parameters passed to the job
+        :return tuple: The result object and the HTTP status code
+        """
         response = self.client.post(
             f'/job/{job_type}',
             data=json.dumps(data),
@@ -106,6 +151,13 @@ class JobTypeTest(unittest.TestCase):
         return data, response.status_code
 
     def stage_resource(self, folder, path):
+        """
+        Copy a resource (file oder folder) to the staging folder.
+
+        :param str folder: The source folder
+        :param str path: The relative path to the resource
+        :return:
+        """
         source = os.path.join(self.resource_dir, folder, path)
         target = os.path.join(self.staging_dir, test_user, path)
         try:
@@ -114,6 +166,12 @@ class JobTypeTest(unittest.TestCase):
             pass
 
     def unstage_resource(self, path):
+        """
+        Removes a resource (file or folder) from the staging folder.
+
+        :param str path: The relative path to the resource in the staging folder
+        :return:
+        """
         source = os.path.join(self.staging_dir, test_user, path)
         try:
             shutil.rmtree(source)
@@ -121,6 +179,12 @@ class JobTypeTest(unittest.TestCase):
             pass
 
     def remove_object_from_repository(self, object_id):
+        """
+        Remove an object from the repository.
+
+        :param str object_id:
+        :return:
+        """
         source = os.path.join(self.repository_dir, object_id)
         try:
             shutil.rmtree(source)
@@ -128,6 +192,13 @@ class JobTypeTest(unittest.TestCase):
             pass
 
     def load_params_from_file(self, folder, path):
+        """
+        Loads job params from a JSON file.
+
+        :param str folder: The source folder
+        :param str path: The relative path to the JSON file
+        :return: The parsed JSON
+        """
         source = os.path.join(self.resource_dir, folder, path)
         with open(source) as data_object:
             data = json.load(data_object)

--- a/test/integration/test_ingest_book.py
+++ b/test/integration/test_ingest_book.py
@@ -3,13 +3,14 @@ from test.integration.job_type_test import JobTypeTest
 
 class IngestBookTest(JobTypeTest):
 
+    test_object_id = "test_object_2342"
+
     def test_success(self):
         self.stage_resource('objects', 'some_tiffs')
         params = self.load_params_from_file('params', 'a_book.json')
 
         data, status_code = self.post_job('ingest_book', params)
         self.assertEquals(status_code, 202)
-        job_id = data['job_id']
         self.assertEqual('Accepted', data['status'])
         self.assert_job_successful(data['task_ids'])
 
@@ -22,7 +23,7 @@ class IngestBookTest(JobTypeTest):
             'meta.json'
         ]
         for file in files_generated:
-            self.assert_file_in_repository(job_id, file)
+            self.assert_file_in_repository(self.test_object_id, file)
 
         self.unstage_resource('some_tiffs')
-        self.remove_object_from_repository(job_id)
+        self.remove_object_from_repository(self.test_object_id)

--- a/test/integration/test_ingest_journal.py
+++ b/test/integration/test_ingest_journal.py
@@ -15,6 +15,12 @@ class IngestJournalTest(JobTypeTest):
         self.assertEqual('Accepted', data['status'])
         self.assert_status(job_id, 'SUCCESS', 120000)
 
+        response = self.get_status(job_id)
+        self.assertIn('object_id', response['result'])
+        object_id = response['result']['object_id']
+        journal_code = params['ojs_metadata']['ojs_journal_code']
+        self.assertTrue(object_id.startswith(f"journal-{journal_code}"))
+
         files_generated = [
             'data/origin/merged.pdf',
             'parts/part_0001/data/origin/merged.pdf',
@@ -31,11 +37,11 @@ class IngestJournalTest(JobTypeTest):
             'ojs_import.xml'
         ]
         for file in files_generated:
-            self.assert_file_in_repository(job_id, file)
+            self.assert_file_in_repository(object_id, file)
 
         # Prüfen ob die generierte XMLs galley enthält, was für den OJS
         # Import und frontmatter generation noetig ist
-        file_path = os.path.join(os.environ['REPOSITORY_DIR'], job_id,
+        file_path = os.path.join(os.environ['REPOSITORY_DIR'], object_id,
                                  'ojs_import.xml')
         with open(file_path, 'r') as f:
             xml_content = f.read()
@@ -52,6 +58,12 @@ class IngestJournalTest(JobTypeTest):
         job_id = data['job_id']
         self.assertEqual('Accepted', data['status'])
         self.assert_status(job_id, 'SUCCESS', 120000)
+
+        response = self.get_status(job_id)
+        self.assertIn('object_id', response['result'])
+        object_id = response['result']['object_id']
+        journal_code = params['ojs_metadata']['ojs_journal_code']
+        self.assertTrue(object_id.startswith(f"journal-{journal_code}"))
 
         files_generated = [
             'parts/part_0001/data/origin/merged.pdf',
@@ -70,5 +82,5 @@ class IngestJournalTest(JobTypeTest):
             'ojs_import.xml'
         ]
         for file in files_generated:
-            self.assert_file_in_repository(job_id, file)
+            self.assert_file_in_repository(object_id, file)
         self.unstage_resource('pdf')

--- a/test/resources/params/a_book.json
+++ b/test/resources/params/a_book.json
@@ -18,5 +18,6 @@
     { "file": "some_tiffs/test2.tiff" },
     { "file": "some_tiffs/test3.TIF" },
     { "file": "some_tiffs/test4.TIFF" }
-  ]
+  ],
+  "object_id": "test_object_2342"
 }

--- a/test/worker/ojs/test_generate_frontmatter.py
+++ b/test/worker/ojs/test_generate_frontmatter.py
@@ -25,12 +25,10 @@ class GenerateFrontmatterTest(unittest.TestCase):
         expecting failure the odd numbers refenrecing txt instead of PDF.
         """
         ojs_import_file = 'test/resources/objects/xml/ojs_import.xml'
-        _, response_text = publish(ojs_import_file, 'test')
-        cls.published_articles.extend(
-            json.loads(response_text)['published_articles'])
-        _, response_text = publish(ojs_import_file, 'test')
-        cls.published_articles.extend(
-            json.loads(response_text)['published_articles'])
+        _, response = publish(ojs_import_file, 'test')
+        cls.published_articles.extend(response['published_articles'])
+        _, response = publish(ojs_import_file, 'test')
+        cls.published_articles.extend(response['published_articles'])
 
     def test_generate_frontmatter(self):
         """
@@ -39,11 +37,11 @@ class GenerateFrontmatterTest(unittest.TestCase):
         Takes the even numbered IDs from the published articles in the setup
         method, which are supposed to be valid PDF files.
         """
-        response_status_code, response_text = \
+        response_status_code, response = \
             generate_frontmatters(self.published_articles[::2])
 
         self.assertEqual(200, response_status_code)
-        self.assertIn('\"success\":true', response_text)
+        self.assertTrue(response['success'])
 
     def test_generate_frontmatter_txt(self):
         """

--- a/test/worker/ojs/test_publish_to_ojs.py
+++ b/test/worker/ojs/test_publish_to_ojs.py
@@ -16,11 +16,10 @@ class PublishToOJSTest(unittest.TestCase):
         """
         ojs_import_file = 'test/resources/objects/xml/ojs_import.xml'
 
-        response_status_code, response_text = publish(ojs_import_file,
-                                                      'test')
+        response_status_code, response = publish(ojs_import_file, 'test')
 
         self.assertEqual(200, response_status_code)
-        self.assertIn('\"success\":true', response_text)
+        self.assertTrue(response['success'])
 
     def test_publish_to_ojs_faulty_xml(self):
         """

--- a/workers/base_task.py
+++ b/workers/base_task.py
@@ -28,6 +28,8 @@ def merge_dicts(a, b, path=None):
     The two dictionaries are merged recursively so that values
     that are themselves dictionaries are merged as well.
 
+    Entries in dict b override values in dict a.
+
     :param dict a:
     :param dict b:
     :param str path:
@@ -39,10 +41,11 @@ def merge_dicts(a, b, path=None):
         if key in a:
             if isinstance(a[key], dict) and isinstance(b[key], dict):
                 merge_dicts(a[key], b[key], path + [str(key)])
-            elif a[key] == b[key]:
-                pass  # same leaf value
+            elif type(a) is type(b):
+                a[key] = b[key]
             else:
-                raise Exception('Conflict at %s' % '.'.join(path + [str(key)]))
+                raise Exception('Conflicting types at %s'
+                                % '.'.join(path + [str(key)]))
         else:
             a[key] = b[key]
     return a

--- a/workers/base_task.py
+++ b/workers/base_task.py
@@ -85,6 +85,13 @@ class BaseTask(Task):
             raise KeyError(f"Mandatory parameter {key} is missing"
                            f" for {self.__class__.__name__}")
 
+    def get_result(self, key):
+        try:
+            return self.params['result'][key]
+        except KeyError:
+            raise KeyError(f"Mandatory result {key} is missing"
+                           f" for {self.__class__.__name__}")
+
     @abstractmethod
     def execute_task(self):
         """

--- a/workers/default/ojs/ojs_api.py
+++ b/workers/default/ojs/ojs_api.py
@@ -1,3 +1,4 @@
+import json
 from urllib.request import Request, urlopen
 
 server = "ojs"
@@ -66,4 +67,4 @@ def _make_request(url, headers, import_data=None):
     with urlopen(request) as response:
         response_text = response.read().decode('utf-8')
 
-    return response.getcode(), response_text
+    return response.getcode(), json.loads(response_text)

--- a/workers/default/ojs/tasks.py
+++ b/workers/default/ojs/tasks.py
@@ -6,6 +6,10 @@ from workers.base_task import BaseTask
 from workers.default.ojs.ojs_api import publish, generate_frontmatters
 
 
+def _generate_object_id(journal_code, result):
+    return f"journal-{journal_code}-{result['published_issues'][0]}"
+
+
 class PublishToOJSTask(BaseTask):
     """
     Publish documents in the XML in the working directory via OJS-Plugin.
@@ -21,8 +25,11 @@ class PublishToOJSTask(BaseTask):
         work_path = self.get_work_path()
         data = self.get_param('ojs_metadata')
 
-        publish(os.path.join(work_path, 'ojs_import.xml'),
-                data['ojs_journal_code'])
+        _, result = publish(os.path.join(work_path, 'ojs_import.xml'),
+                            data['ojs_journal_code'])
+
+        object_id = _generate_object_id(data['ojs_journal_code'], result)
+        return {'object_id': object_id}
 
 
 class GenerateFrontmatterTask(BaseTask):

--- a/workers/default/repository/tasks.py
+++ b/workers/default/repository/tasks.py
@@ -38,7 +38,7 @@ class CreateObjectTask(BaseTask):
         _add_files(obj, files, user)
         if 'parts' in self.params:
             self._execute_for_parts(obj, self.get_param('parts'), user)
-        return {'object_id': self.job_id}
+        return {'object_id': self._get_object_id()}
 
     def _execute_for_parts(self, obj, parts, user):
         for part in parts:
@@ -50,6 +50,15 @@ class CreateObjectTask(BaseTask):
 
             if 'parts' in part:
                 self._execute_for_parts(child, part['parts'], user)
+
+    def _get_object_id(self):
+        try:
+            object_id = self.get_param('object_id')
+        except KeyError:
+            object_id = self.job_id
+        if not object_id:
+            object_id = self.job_id
+        return object_id
 
 
 CreateObjectTask = celery_app.register_task(CreateObjectTask())

--- a/workers/default/repository/tasks.py
+++ b/workers/default/repository/tasks.py
@@ -38,6 +38,7 @@ class CreateObjectTask(BaseTask):
         _add_files(obj, files, user)
         if 'parts' in self.params:
             self._execute_for_parts(obj, self.get_param('parts'), user)
+        return {'object_id': self.job_id}
 
     def _execute_for_parts(self, obj, parts, user):
         for part in parts:
@@ -85,7 +86,8 @@ class PublishToRepositoryTask(BaseTask):
 
     def execute_task(self):
         work_path = self.get_work_path()
-        repository_path = os.path.join(repository_dir, self.job_id)
+        repository_path = os.path.join(repository_dir,
+                                       self.get_result('object_id'))
         shutil.rmtree(repository_path, ignore_errors=True)
         shutil.copytree(work_path, repository_path)
 


### PR DESCRIPTION
The object-id used for publication in the repository can now be set by param or by some previous task in the chain. `create_object` reads the param and sets the `object_id` in the result dictionary accordingly or to generated id (the job id) if none was given.