### PR TITLE
Mysterious bug

### DIFF
--- a/workers/base_task.py
+++ b/workers/base_task.py
@@ -79,6 +79,7 @@ class BaseTask(Task):
         return abs_path
 
     def run(self, prev_result=None, **params):
+        self.results = {}
         self._init_params(params)
         self._add_prev_result_to_results(prev_result)
         return self._merge_result(self.execute_task())

--- a/workers/base_task.py
+++ b/workers/base_task.py
@@ -81,7 +81,11 @@ class BaseTask(Task):
     def run(self, prev_result=None, **params):
         self.results = {}
         self._init_params(params)
-        self._add_prev_result_to_results(prev_result)
+        if prev_result:
+            self._add_prev_result_to_results(prev_result)
+        # results can also be part of the params array in some cases
+        if 'result' in params:
+            self._add_prev_result_to_results(params['result'])
         return self._merge_result(self.execute_task())
 
     def get_param(self, key):

--- a/workers/default/utils/tasks.py
+++ b/workers/default/utils/tasks.py
@@ -51,7 +51,10 @@ class ListFilesTask(ObjectTask):
             params = self.params.copy()
             params['job_id'] = self.job_id
             params['work_path'] = file
-
+            # workaround for storing results inside params
+            # this is necessary since prev_results do not always seem to be
+            # passed to subtasks correctly by celery
+            params['result'] = self.results
             chain = generate_chain(subtasks, params)
             group_tasks.append(chain)
         return group(group_tasks)
@@ -86,6 +89,10 @@ class ListPartsTask(ObjectTask):
         for part in obj.get_parts():
             params = self.params.copy()
             params['work_path'] = part.path
+            # workaround for storing results inside params
+            # this is necessary since prev_results do not always seem to be
+            # passed to subtasks correctly by celery
+            params['result'] = self.results
             chain = generate_chain(subtasks, params)
             group_tasks.append(chain)
         return group(group_tasks)


### PR DESCRIPTION
This fixes a bug that caused older results from other jobs to be
returned in a seemingly random fashion.

Tasks that are created in list_files and list_parts now get an
additional param 'result' which is evaluated in addition to the
prev_result param in the base task.

See: http://dai-softsource.uni-koeln.de/issues/9467