### PR TITLE
Frontend

### DIFF
--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -77,3 +77,6 @@ angular
         return filtered;
     };
 });
+
+
+

--- a/frontend/js/controllers/view_overview.js
+++ b/frontend/js/controllers/view_overview.js
@@ -38,7 +38,11 @@ angular
         // open file externally
         $scope.openDocument = function(article) {
             console.log("Open Document: " + article.filepath.value.value);
-            window.open(settings.files_url + article.filepath.value.value);
+            let nameEncode = encodeURIComponent("test_user");
+            let pwEncode = encodeURIComponent("test_password");
+            let split = settings.files_url.split(/\/\//, 2);
+
+            window.open(split[0] + "//" + nameEncode + ":" + pwEncode + "@" + split[1] + article.filepath.value.value);
         };
 
         /* merging articles */

--- a/frontend/js/services/steps.js
+++ b/frontend/js/services/steps.js
@@ -2,19 +2,24 @@
 
 angular
 .module('module.steps', [])
-.factory("steps", ['fileManager', 'dataset', 'messenger', function(fileManager, dataset, messenger) {
+.factory("steps", ['fileManager', 'dataset', 'messenger', 'webservice', function(fileManager, dataset, messenger, webservice) {
 
     const cacheKiller = '?nd=' + Date.now();
 
     let steps = {
-        current : "home",
+        current : "start",
         isStarted: false
     };
 
     steps.views = {
+        "start": {
+            "template": "partials/views/start_page.html",
+            "title": "Start",
+            "showIf": function() {return false}
+        },
         "home": {
             "template": "partials/views/home.html",
-            "title": "Start",
+            "title": "Home",
             "showIf": function() {return !steps.isStarted && steps.current != "fatal"}
         },
         "restart": {
@@ -99,6 +104,8 @@ angular
     };
 
     steps.getTemplate = function() {
+        if (webservice.userData.username === null && webservice.userData.password === null)
+            steps.current = "start";
         if (angular.isUndefined(steps.views[steps.current]) || angular.isUndefined(steps.views[steps.current].template)) {
             messenger.error("View '" + steps.current + "' not found.");
             steps.current = "fatal";

--- a/frontend/js/services/steps.js
+++ b/frontend/js/services/steps.js
@@ -55,31 +55,31 @@ angular
     };
 
     let tabs = {
-        current: "data",
+        current: "messages",
         isCollapsed: false
-    }
+    };
 
     steps.tabs = {
         "data": {
             "template": "partials/elements/sidebar_data.html",
             "title": "My Data",
-            "showIf": function() {return steps.isStarted && steps.current != "fatal" && tabs.current != "data"}
+            "showIf": function() {return steps.isStarted && steps.current !== "fatal" && tabs.current !== "data"}
         },
         "help": {
             "template": "partials/elements/sidebar_help.html",
             "title": "Help",
-            "showIf": function() {return steps.isStarted && steps.current != "fatal"  && tabs.current != "help"}
+            "showIf": function() {return steps.isStarted && steps.current !== "fatal"  && tabs.current !== "help"}
         },
         "messages": {
             "template": "partials/elements/sidebar_messages.html",
             "title": "Messages",
-            "showIf": function() {return steps.isStarted && steps.current != "fatal"  && tabs.current != "messages"}
+            "showIf": function() {return steps.isStarted && steps.current !== "fatal"  && tabs.current !== "messages"}
         }
     };
 
     steps.getCurrent = (tab) => {
         return (tabs.current === tab);
-    }
+    };
 
     steps.changeView = function(to) {
 

--- a/frontend/partials/views/start_page.html
+++ b/frontend/partials/views/start_page.html
@@ -1,0 +1,1 @@
+<h3>Willkommen auf idai.Workbench</h3>

--- a/frontend/test/e2e/specs/overview.spec.js
+++ b/frontend/test/e2e/specs/overview.spec.js
@@ -112,7 +112,7 @@ describe('overview page', () => {
         expect(ot.getRowTitle(1)).toEqual(titleDoc1);
     });
 
-    xit('should open pdf in other tab on btn click', () => { // see #9363
+    it('should open pdf in other tab on btn click', () => { // see #9363
         ot.goToOverview(2);
         ot.getRowButton(0, 'open').click();
         a.switchToNewTab().then(() => {

--- a/workers/base_task.py
+++ b/workers/base_task.py
@@ -79,8 +79,13 @@ class BaseTask(Task):
         return abs_path
 
     def run(self, prev_result=None, **params):
+        self.results = {}
         self._init_params(params)
-        self._add_prev_result_to_results(prev_result)
+        if prev_result:
+            self._add_prev_result_to_results(prev_result)
+        # results can also be part of the params array in some cases
+        if 'result' in params:
+            self._add_prev_result_to_results(params['result'])
         return self._merge_result(self.execute_task())
 
     def get_param(self, key):

--- a/workers/default/utils/tasks.py
+++ b/workers/default/utils/tasks.py
@@ -51,7 +51,10 @@ class ListFilesTask(ObjectTask):
             params = self.params.copy()
             params['job_id'] = self.job_id
             params['work_path'] = file
-
+            # workaround for storing results inside params
+            # this is necessary since prev_results do not always seem to be
+            # passed to subtasks correctly by celery
+            params['result'] = self.results
             chain = generate_chain(subtasks, params)
             group_tasks.append(chain)
         return group(group_tasks)
@@ -86,6 +89,10 @@ class ListPartsTask(ObjectTask):
         for part in obj.get_parts():
             params = self.params.copy()
             params['work_path'] = part.path
+            # workaround for storing results inside params
+            # this is necessary since prev_results do not always seem to be
+            # passed to subtasks correctly by celery
+            params['result'] = self.results
             chain = generate_chain(subtasks, params)
             group_tasks.append(chain)
         return group(group_tasks)


### PR DESCRIPTION
Bug #9363 Open PDF without passing credentials manually

Name and password are now encoded in UTF-8 and passed to the default PDF-viewer via window.open. Therefore it's not necessary to input credentials manually anymore, but there could be a possible safety-problem. PDF-test reactivated.