### PR TITLE
Nlp per object

### DIFF
--- a/config/job_types/ingest_journal.yml
+++ b/config/job_types/ingest_journal.yml
@@ -36,8 +36,7 @@ tasks:
         foreach:
           task: convert.pdf_to_txt
           target: txt
-    - list_files: txt
-      foreach: nlp.annotate
+    - nlp.annotate
   - task: generate_xml
     template_file: ojs_template.xml
     target_filename: ojs_import.xml

--- a/config/job_types/ingest_journal.yml
+++ b/config/job_types/ingest_journal.yml
@@ -36,7 +36,8 @@ tasks:
         foreach:
           task: convert.pdf_to_txt
           target: txt
-    - nlp.annotate
+    - task: nlp.annotate
+      source: txt
   - task: generate_xml
     template_file: ojs_template.xml
     target_filename: ojs_import.xml

--- a/test/integration/test_ingest_journal.py
+++ b/test/integration/test_ingest_journal.py
@@ -29,13 +29,13 @@ class IngestJournalTest(JobTypeTest):
             'parts/part_0001/marc.xml',
             'parts/part_0001/mets.xml',
             'parts/part_0001/data/txt/merged_0.txt',
-            'parts/part_0001/data/txt/merged_0.json',
+            'parts/part_0001/data/txt/annotations.json',
             'parts/part_0002/data/origin/merged.pdf',
             'parts/part_0002/meta.json',
             'parts/part_0002/marc.xml',
             'parts/part_0002/mets.xml',
             'parts/part_0002/data/txt/merged_0.txt',
-            'parts/part_0002/data/txt/merged_0.json',
+            'parts/part_0002/data/txt/annotations.json',
             'meta.json',
             'ojs_import.xml'
             ]
@@ -75,13 +75,13 @@ class IngestJournalTest(JobTypeTest):
             'parts/part_0001/marc.xml',
             'parts/part_0001/data/tif/merged_0.tif',
             'parts/part_0001/data/txt/merged_0.txt',
-            'parts/part_0001/data/txt/merged_0.json',
+            'parts/part_0001/data/txt/annotations.json',
             'parts/part_0002/data/origin/merged.pdf',
             'parts/part_0002/meta.json',
             'parts/part_0002/marc.xml',
             'parts/part_0002/data/tif/merged_0.tif',
             'parts/part_0002/data/txt/merged_0.txt',
-            'parts/part_0002/data/txt/merged_0.json',
+            'parts/part_0002/data/txt/annotations.json',
             'meta.json',
             'ojs_import.xml'
             ]

--- a/test/utils/test_sorting_algorithms.py
+++ b/test/utils/test_sorting_algorithms.py
@@ -1,0 +1,11 @@
+import unittest
+
+from utils.sorting_algorithms import sort_alphanumeric
+
+
+class SortingAlgorithmsTest(unittest.TestCase):
+    def test_sort_aplhanumeric(self):
+        dir_list = ['test_1.txt', 'test.txt', 'test_11.txt', 'test_2.txt']
+        res_list = sort_alphanumeric(dir_list)
+        sup_res_list = ['test.txt', 'test_1.txt', 'test_2.txt', 'test_11.txt']
+        self.assertEqual(res_list, sup_res_list)

--- a/utils/object.py
+++ b/utils/object.py
@@ -5,7 +5,9 @@ import json
 from pathlib import Path
 from typing import List, Iterator, TextIO
 from distutils.dir_util import copy_tree
+
 from utils.serialization import SerializableClass
+from utils.sorting_algorithms import sort_alphanumeric
 
 
 class PathDoesNotExist(Exception):
@@ -174,7 +176,7 @@ class Object:
         """
         representations = []
         path = self.get_representation_dir(representation)
-        for filename in os.listdir(path):
+        for filename in sort_alphanumeric(os.listdir(path)):
             if not os.path.isdir(os.path.join(path, filename)):
                 with open(os.path.join(path, filename), 'rb') as file:
                     representations.append(BytesIO(file.read()))

--- a/utils/sorting_algorithms.py
+++ b/utils/sorting_algorithms.py
@@ -1,0 +1,21 @@
+import re
+
+
+def sort_alphanumeric(it):
+    """
+    Sorts the given iterable in the way that is expected.
+
+    E.g. test.txt, test_1.txt, test_2.txt, test_11.txt
+
+    :param iterable it: Iterable to be sorted
+    :return iterable: Sorted iterable
+
+    """
+    def _convert(text):
+        if text.isdigit():
+            return int(text)
+        else:
+            return text
+
+    return sorted(it, key=lambda key: [_convert(c) for c in re.split('([0-9]+)',
+                                                                     key)])

--- a/workers/nlp/annotate/annotate.py
+++ b/workers/nlp/annotate/annotate.py
@@ -107,7 +107,7 @@ def _create_json_for_entity_type(entities):
             "id": str(uuid.uuid1()),
             "score": None,
             "terms": [entity["string"]],
-            "pages": [1],  # as long as only one page is processed
+            "pages": [entity["page"]],  # as long as every match is its own entry
             "count": 1,  # as long as every match is its own entry
             "lemma": entity["normform"],
             "coordinates": coordinates,

--- a/workers/nlp/annotate/annotate.py
+++ b/workers/nlp/annotate/annotate.py
@@ -93,10 +93,11 @@ def _create_json_for_entity_type(nlp_entities):
                    if (x["lemma"] == nlp_entity["normform"])]
         if matches:
             match = matches[0]
+            index = viewer_entities.index(match)
             match["terms"].append(nlp_entity["string"])
             match["count"] += 1
             match["pages"].append(nlp_entity["page"])
-            viewer_entities[viewer_entities.index(match)] = match
+            viewer_entities[index] = match
         else:
             try:
                 coordinates = [nlp_entity["latitude"], nlp_entity["longitude"]]

--- a/workers/nlp/annotate/annotate.py
+++ b/workers/nlp/annotate/annotate.py
@@ -73,47 +73,61 @@ def _generatere_viewer_json(persons, geotagged_locations):
     return viewer_json
 
 
-def _create_json_for_entity_type(entities):
+def _create_json_for_entity_type(nlp_entities):
     """
     Create JSON for every entity type.
 
     This is compatible to the viewer and the same for every entity type
         (person, location). Not used keys are filled with None
-        (null in JSON).
-    :param list entities: all entities of an entity type
-    :return dict: viewer_compatible json of this entity type
+        (null in JSON). Join entities with the same lemma/normform.
+
+    :param list nlp_entities: all entities of an entity type as given by
+        the components
+    :return dict: viewer compatible json of this entity type
     """
+
     viewer_entities = []
-    for entity in entities:
-        try:
-            coordinates = [entity["latitude"], entity["longitude"]]
-        except KeyError:
-            coordinates = None
+    for nlp_entity in nlp_entities:
 
-        references = []
-        for key, value in entity["refids"].items():
+        matches = [x for x in viewer_entities
+                   if (x["lemma"] == nlp_entity["normform"])]
+        if matches:
+            match = matches[0]
+            match["terms"].append(nlp_entity["string"])
+            match["count"] += 1
+            match["pages"].append(nlp_entity["page"])
+            viewer_entities[viewer_entities.index(match)] = match
+        else:
             try:
-                url = f"{entity['_baseurls'][key]}{value}"
-                reference = {
-                    "id": value,
-                    "url": url,
-                    "type": key
-                }
+                coordinates = [nlp_entity["latitude"], nlp_entity["longitude"]]
             except KeyError:
-                reference = {}
-            references.append(reference)
+                coordinates = None
 
-        viewer_entity = {
-            "id": str(uuid.uuid1()),
-            "score": None,
-            "terms": [entity["string"]],
-            "pages": [entity["page"]],  # as long as every match is its own entry
-            "count": 1,  # as long as every match is its own entry
-            "lemma": entity["normform"],
-            "coordinates": coordinates,
-            "references": references
-        }
-        viewer_entities.append(viewer_entity)
+            references = []
+            for key, value in nlp_entity["refids"].items():
+                try:
+                    url = f"{nlp_entity['_baseurls'][key]}{value}"
+                    reference = {
+                        "id": value,
+                        "url": url,
+                        "type": key
+                    }
+                except KeyError:
+                    reference = {}
+                references.append(reference)
+
+            viewer_entity = {
+                "id": str(uuid.uuid1()),
+                "score": None,
+                "terms": [nlp_entity["string"]],
+                "pages": [nlp_entity["page"]],
+                "count": 1,
+                "lemma": nlp_entity["normform"],
+                "coordinates": coordinates,
+                "references": references
+            }
+            viewer_entities.append(viewer_entity)
+
     return viewer_entities
 
 

--- a/workers/nlp/annotate/tasks.py
+++ b/workers/nlp/annotate/tasks.py
@@ -33,9 +33,11 @@ AnnotateTask = celery_app.register_task(AnnotateTask())
 
 def _get_full_text(folder):
     """
-    Get the full text from the seperated txts
-    Make it to one big string with new-page markers in it. This improves
-    both, quality and runtime of the annotations
+    Get the full text from the seperated txts.
+
+    Make it to one big string with new-page markers (\f)in it. This
+    improves both, quality and runtime of the annotations.
+
     :param str folder: The folder which is searched for the txts
     :return str: The complete text, merged from all txts
     """

--- a/workers/nlp/annotate/tasks.py
+++ b/workers/nlp/annotate/tasks.py
@@ -19,7 +19,7 @@ class AnnotateTask(ObjectTask):
     name = "nlp.annotate"
 
     def process_object(self, obj):
-        txt_folder = os.path.join(obj.path, "data", "txt")
+        txt_folder = obj.get_representation_dir(self.get_param('source'))
         full_text = _get_full_text(txt_folder)
         json_file = os.path.join(txt_folder, "annotations.json")
 

--- a/workers/nlp/annotate/tasks.py
+++ b/workers/nlp/annotate/tasks.py
@@ -19,37 +19,29 @@ class AnnotateTask(ObjectTask):
     name = "nlp.annotate"
 
     def process_object(self, obj):
-        txt_folder = obj.get_representation_dir(self.get_param('source'))
-        full_text = _get_full_text(txt_folder)
-        json_file = os.path.join(txt_folder, "annotations.json")
+        full_text = self._get_full_text(obj)
+        json_file = os.path.join(obj.get_representation_dir(
+            self.get_param('source')), "annotations.json")
 
         result = annotate(full_text)
         with open(json_file, 'w+') as file:
             json.dump(result, file)
 
+    def _get_full_text(self, obj):
+        """
+        Get the full text from the seperated txts.
+
+        Make it to one big string with new-page markers (\f)in it. This
+        improves both, quality and runtime of the annotations.
+
+        :param class obj: The object
+        :return str: The complete text, merged from all txts
+        """
+        full_text = ""
+        for file2 in obj.get_representation(self.get_param('source')):
+            text = file2.read().decode("UTF-8").replace('\n', '')
+            full_text += f"{text}\f"
+        return full_text
+
 
 AnnotateTask = celery_app.register_task(AnnotateTask())
-
-
-def _get_full_text(folder):
-    """
-    Get the full text from the seperated txts.
-
-    Make it to one big string with new-page markers (\f)in it. This
-    improves both, quality and runtime of the annotations.
-
-    :param str folder: The folder which is searched for the txts
-    :return str: The complete text, merged from all txts
-    """
-    full_text = ""
-    page = 0
-    while True:
-        file = os.path.join(folder, f"merged_{page}.txt")
-        if os.path.isfile(file):
-            with open(file, 'r') as f:
-                text = f.read().replace('\n', '')
-                full_text += f"{text}\f"
-            page += 1
-        else:
-            break
-    return full_text


### PR DESCRIPTION
Annotations now run per object (e.g. article) and not per page anymore. This should improve the runtime and the quality of the results (or at least it doesn't decrease it). Annotations with the same normform (e.g. "BRAUNSCHWEIG" and "Braunschweig" ) are now merged. This removes redundant data and makes it easier for the viewer to process the results.