### PR TITLE
Add worker task for scaling images

### DIFF
--- a/config/job_types/ingest_journal.yml
+++ b/config/job_types/ingest_journal.yml
@@ -10,6 +10,8 @@ params:
   nlp_params: dict
   do_ocr: boolean
   ojs_metadata: dict
+  image_max_width: string
+  image_max_height: string
 
 tasks:
   - create_object
@@ -38,6 +40,16 @@ tasks:
           target: txt
     - list_files: txt
       foreach: nlp.annotate
+  - list_parts:
+    foreach:
+      list_files: jpg
+      foreach:
+        task: image.scaling
+  - list_parts:
+    foreach:
+      list_files: tif
+      foreach:
+        task: image.scaling
   - task: generate_xml
     template_file: ojs_template.xml
     target_filename: ojs_import.xml
@@ -59,6 +71,6 @@ tasks:
     params: ojs_metadata
   - list_parts:
     foreach:
-        task: generate_frontmatter
+      task: generate_frontmatter
   - publish_to_repository
   - cleanup_workdir

--- a/config/job_types/ingest_journal.yml
+++ b/config/job_types/ingest_journal.yml
@@ -10,8 +10,6 @@ params:
   nlp_params: dict
   do_ocr: boolean
   ojs_metadata: dict
-  image_max_width: string
-  image_max_height: string
 
 tasks:
   - create_object
@@ -45,11 +43,15 @@ tasks:
       list_files: jpg
       foreach:
         task: image.scaling
+        max_width: 50
+        max_height: 50
   - list_parts:
     foreach:
       list_files: tif
       foreach:
         task: image.scaling
+        max_width: 50
+        max_height: 50
   - task: generate_xml
     template_file: ojs_template.xml
     target_filename: ojs_import.xml

--- a/test/resources/params/a_journal.json
+++ b/test/resources/params/a_journal.json
@@ -82,7 +82,5 @@
         "default_create_frontpage": true,
         "allow_upload_without_file": false
     },
-    "do_ocr": false,
-    "image_max_width": "50",
-    "image_max_height": "30"
+    "do_ocr": false
 }

--- a/test/resources/params/a_journal.json
+++ b/test/resources/params/a_journal.json
@@ -82,5 +82,7 @@
         "default_create_frontpage": true,
         "allow_upload_without_file": false
     },
-    "do_ocr": false
+    "do_ocr": false,
+    "image_max_width": "50",
+    "image_max_height": "30"
 }

--- a/test/resources/params/a_journal_do_ocr.json
+++ b/test/resources/params/a_journal_do_ocr.json
@@ -82,7 +82,5 @@
         "default_create_frontpage": true,
         "allow_upload_without_file": false
     },
-    "do_ocr": true,
-    "image_max_width": "50",
-    "image_max_height": "30"
+    "do_ocr": true
 }

--- a/test/resources/params/a_journal_do_ocr.json
+++ b/test/resources/params/a_journal_do_ocr.json
@@ -82,5 +82,7 @@
         "default_create_frontpage": true,
         "allow_upload_without_file": false
     },
-    "do_ocr": true
+    "do_ocr": true,
+    "image_max_width": "50",
+    "image_max_height": "30"
 }

--- a/test/worker/image/test_convert_image.py
+++ b/test/worker/image/test_convert_image.py
@@ -1,0 +1,31 @@
+import unittest
+import os
+
+from workers.default.image.image_scaling import scale_image
+
+
+class ConvertImageTest(unittest.TestCase):
+    """
+    Test the image scaling functions.
+
+    Basically just taking an existing image file, passing it to the function
+    with arbitrary parameters and checking if another file was generated.
+    """
+
+    resource_dir = os.environ['RESOURCE_DIR']
+
+    def test_scale_jpg(self):
+        """Test scaling for JPEG type image."""
+        image_file = os.path.join(self.resource_dir, 'test.jpg')
+        scale_image(image_file, "30", "40", self.resource_dir)
+        self.assertTrue(os.path.isfile(
+            f'{self.resource_dir}/test_30_40.jpg'))
+        os.remove(f'{self.resource_dir}/test_30_40.jpg')
+
+    def test_scale_tif(self):
+        """Test scaling for TIFF type image."""
+        image_file = os.path.join(self.resource_dir, 'test.tif')
+        scale_image(image_file, "30", "40", self.resource_dir)
+        self.assertTrue(os.path.isfile(
+            f'{self.resource_dir}/test_30_40.tif'))
+        os.remove(f'{self.resource_dir}/test_30_40.tif')

--- a/test/worker/image/test_convert_image.py
+++ b/test/worker/image/test_convert_image.py
@@ -17,7 +17,7 @@ class ConvertImageTest(unittest.TestCase):
     def test_scale_jpg(self):
         """Test scaling for JPEG type image."""
         image_file = os.path.join(self.resource_dir, 'test.jpg')
-        scale_image(image_file, "30", "40", self.resource_dir)
+        scale_image(image_file, 30, 40, self.resource_dir)
         self.assertTrue(os.path.isfile(
             f'{self.resource_dir}/test_30_40.jpg'))
         os.remove(f'{self.resource_dir}/test_30_40.jpg')
@@ -25,7 +25,7 @@ class ConvertImageTest(unittest.TestCase):
     def test_scale_tif(self):
         """Test scaling for TIFF type image."""
         image_file = os.path.join(self.resource_dir, 'test.tif')
-        scale_image(image_file, "30", "40", self.resource_dir)
+        scale_image(image_file, 30, 40, self.resource_dir)
         self.assertTrue(os.path.isfile(
             f'{self.resource_dir}/test_30_40.tif'))
         os.remove(f'{self.resource_dir}/test_30_40.tif')

--- a/workers/default/image/image_scaling.py
+++ b/workers/default/image/image_scaling.py
@@ -1,10 +1,9 @@
 import logging
-import os
 
 from PIL import Image as PilImage
 
 
-def scale_image(image_path, max_width, max_height, target_dir):
+def scale_image(image_path, max_width, max_height, target_file_name):
     """
     Scale the image to the given size keeping aspect ratio.
 
@@ -22,14 +21,8 @@ def scale_image(image_path, max_width, max_height, target_dir):
     """
     logging.getLogger(__name__).debug(f"Resizing {image_path} "
                                       f"to size: {(max_width, max_height)}")
-    file_name = os.path.splitext(os.path.basename(image_path))[0]
-    file_extension = os.path.splitext(os.path.basename(image_path))[1]
-    new_file_name = file_name +\
-        "_" + str(max_width) +\
-        "_" + str(max_height) +\
-        "." + file_extension
 
     # conversion is needed for tiffs
     image = PilImage.open(image_path).convert('RGB')
     image.thumbnail((max_width, max_height))
-    image.save(os.path.join(target_dir, new_file_name))
+    image.save(target_file_name)

--- a/workers/default/image/image_scaling.py
+++ b/workers/default/image/image_scaling.py
@@ -6,14 +6,19 @@ from PIL import Image as PilImage
 
 def scale_image(image_path, max_width, max_height, target_dir):
     """
-    Scale the image to the given size.
+    Scale the image to the given size keeping aspect ratio.
 
     Open the given image and scales the size to the given values for
-    width and height.
+    width and height while keeping the aspect ratio.
     The new file will be named like the original one with the new size added
     with underscores.
 
-    Tested working for JPG and TIF.
+    Tested working for JPEG and TIFF.
+
+    :param image_path: path to the image to be scaled
+    :param max_width: maximum width in pixels of the generated image
+    :param max_height: maximum height in pixels of the generated image
+    :param target_dir: directory to save the generated image to
     """
     logging.getLogger(__name__).debug(f"Resizing {image_path} "
                                       f"to size: {(max_width, max_height)}")

--- a/workers/default/image/image_scaling.py
+++ b/workers/default/image/image_scaling.py
@@ -14,10 +14,10 @@ def scale_image(source_path, target_path, max_width, max_height):
 
     Tested working for JPEG and TIFF.
 
-    :param source_path: path to the image to be scaled
-    :param target_path: path to save the generated image to
-    :param max_width: maximum width in pixels of the generated image
-    :param max_height: maximum height in pixels of the generated image
+    :param str source_path: path to the image to be scaled
+    :param str target_path: path to save the generated image to
+    :param int max_width: maximum width in pixels of the generated image
+    :param int max_height: maximum height in pixels of the generated image
     """
     logging.getLogger(__name__).debug(f"Resizing {source_path} "
                                       f"to size: {(max_width, max_height)}")

--- a/workers/default/image/image_scaling.py
+++ b/workers/default/image/image_scaling.py
@@ -1,0 +1,30 @@
+import logging
+import os
+
+from PIL import Image as PilImage
+
+
+def scale_image(image_path, max_width, max_height, target_dir):
+    """
+    Scale the image to the given size.
+
+    Open the given image and scales the size to the given values for
+    width and height.
+    The new file will be named like the original one with the new size added
+    with underscores.
+
+    Tested working for JPG and TIF.
+    """
+    logging.getLogger(__name__).debug(f"Resizing {image_path} "
+                                      f"to size: {(max_width, max_height)}")
+    file_name = os.path.splitext(os.path.basename(image_path))[0]
+    file_extension = os.path.splitext(os.path.basename(image_path))[1]
+    new_file_name = file_name +\
+        "_" + str(max_width) +\
+        "_" + str(max_height) +\
+        "." + file_extension
+
+    # conversion is needed for tiffs
+    image = PilImage.open(image_path).convert('RGB')
+    image.thumbnail((max_width, max_height))
+    image.save(os.path.join(target_dir, new_file_name))

--- a/workers/default/image/image_scaling.py
+++ b/workers/default/image/image_scaling.py
@@ -3,7 +3,7 @@ import logging
 from PIL import Image as PilImage
 
 
-def scale_image(image_path, max_width, max_height, target_file_name):
+def scale_image(source_path, target_path, max_width, max_height):
     """
     Scale the image to the given size keeping aspect ratio.
 
@@ -14,15 +14,15 @@ def scale_image(image_path, max_width, max_height, target_file_name):
 
     Tested working for JPEG and TIFF.
 
-    :param image_path: path to the image to be scaled
+    :param source_path: path to the image to be scaled
+    :param target_path: path to save the generated image to
     :param max_width: maximum width in pixels of the generated image
     :param max_height: maximum height in pixels of the generated image
-    :param target_dir: directory to save the generated image to
     """
-    logging.getLogger(__name__).debug(f"Resizing {image_path} "
+    logging.getLogger(__name__).debug(f"Resizing {source_path} "
                                       f"to size: {(max_width, max_height)}")
 
     # conversion is needed for tiffs
-    image = PilImage.open(image_path).convert('RGB')
+    image = PilImage.open(source_path).convert('RGB')
     image.thumbnail((max_width, max_height))
-    image.save(target_file_name)
+    image.save(target_path)

--- a/workers/default/image/tasks.py
+++ b/workers/default/image/tasks.py
@@ -1,0 +1,31 @@
+
+from utils.celery_client import celery_app
+from workers.base_task import FileTask
+from workers.default.image.image_scaling import scale_image
+
+
+class ScaleImageTask(FileTask):
+    """
+    Creates copies of image files with new proportions.
+
+    TaskParams:
+    -str image_max_width: width of the generated image file
+    -str image_max_height: height of the generated image file
+
+    Preconditions:
+    - image files existing
+
+    Creates:
+    - scaled copies of images
+    """
+
+    name = "image.scaling"
+
+    def process_file(self, file, target_dir):
+        """Read parameters and call the actual function."""
+        new_width = int(self.get_param('image_max_width'))
+        new_height = int(self.get_param('image_max_height'))
+        scale_image(file, new_width, new_height, target_dir)
+
+
+ScaleImageTask = celery_app.register_task(ScaleImageTask())

--- a/workers/default/image/tasks.py
+++ b/workers/default/image/tasks.py
@@ -1,3 +1,4 @@
+import os
 
 from utils.celery_client import celery_app
 from workers.base_task import FileTask
@@ -25,7 +26,16 @@ class ScaleImageTask(FileTask):
         """Read parameters and call the actual function."""
         new_width = int(self.get_param('image_max_width'))
         new_height = int(self.get_param('image_max_height'))
-        scale_image(file, new_width, new_height, target_dir)
+
+        file_name = os.path.splitext(os.path.basename(file))[0]
+        file_extension = os.path.splitext(os.path.basename(file))[1]
+        new_file_name = file_name +\
+            "_" + str(new_width) +\
+            "_" + str(new_height) +\
+            "." + file_extension
+
+        scale_image(file, new_width, new_height,
+                    os.path.join(target_dir, new_file_name))
 
 
 ScaleImageTask = celery_app.register_task(ScaleImageTask())

--- a/workers/default/image/tasks.py
+++ b/workers/default/image/tasks.py
@@ -31,8 +31,8 @@ class ScaleImageTask(FileTask):
         file_extension = os.path.splitext(os.path.basename(file))[1]
         new_file_name = f"{file_name}_{new_width}_{new_height}.{file_extension}"
 
-        scale_image(file, new_width, new_height,
-                    os.path.join(target_dir, new_file_name))
+        scale_image(file, os.path.join(target_dir, new_file_name),
+                    new_width, new_height)
 
 
 ScaleImageTask = celery_app.register_task(ScaleImageTask())

--- a/workers/default/image/tasks.py
+++ b/workers/default/image/tasks.py
@@ -6,14 +6,14 @@ from workers.default.image.image_scaling import scale_image
 
 class ScaleImageTask(FileTask):
     """
-    Creates copies of image files with new proportions.
+    Creates copies of image files with new proportions while keeping ratio.
 
     TaskParams:
     -str image_max_width: width of the generated image file
     -str image_max_height: height of the generated image file
 
     Preconditions:
-    - image files existing
+    - image files existing in format JPEG or TIFF
 
     Creates:
     - scaled copies of images

--- a/workers/default/image/tasks.py
+++ b/workers/default/image/tasks.py
@@ -24,15 +24,12 @@ class ScaleImageTask(FileTask):
 
     def process_file(self, file, target_dir):
         """Read parameters and call the actual function."""
-        new_width = int(self.get_param('image_max_width'))
-        new_height = int(self.get_param('image_max_height'))
+        new_width = int(self.get_param('max_width'))
+        new_height = int(self.get_param('max_height'))
 
         file_name = os.path.splitext(os.path.basename(file))[0]
         file_extension = os.path.splitext(os.path.basename(file))[1]
-        new_file_name = file_name +\
-            "_" + str(new_width) +\
-            "_" + str(new_height) +\
-            "." + file_extension
+        new_file_name = f"{file_name}_{new_width}_{new_height}.{file_extension}"
 
         scale_image(file, new_width, new_height,
                     os.path.join(target_dir, new_file_name))

--- a/workers/default/tasks.py
+++ b/workers/default/tasks.py
@@ -4,5 +4,6 @@ celery_app.autodiscover_tasks([
     'workers.default.repository',
     'workers.default.utils',
     'workers.default.xml',
-    'workers.default.ojs'
+    'workers.default.ojs',
+    'workers.default.image'
     ], force=True)


### PR DESCRIPTION
The task takes a maximum width and height and scales the image down.
Tested and working for TIFF and JPEG.

Solves #9375