### PR TITLE
Authentication rework #11187

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2053,6 +2053,16 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "aria-query": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+      "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7",
+        "commander": "^2.11.0"
+      }
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -2197,6 +2207,12 @@
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
+    "ast-types-flow": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+      "dev": true
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -2306,6 +2322,15 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
+      }
+    },
+    "axobject-query": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
+      "integrity": "sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7"
       }
     },
     "babel-code-frame": {
@@ -3870,6 +3895,12 @@
         "proto-list": "~1.2.1"
       }
     },
+    "confusing-browser-globals": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.7.tgz",
+      "integrity": "sha512-cgHI1azax5ATrZ8rJ+ODDML9Fvu67PimB6aNxBrc/QwSaDaM9eTfIEUHx3bBLJJ82ioSb+/5zfsMCCEJax3ByQ==",
+      "dev": true
+    },
     "connect-history-api-fallback": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
@@ -4522,6 +4553,12 @@
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
       "dev": true
     },
+    "damerau-levenshtein": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.5.tgz",
+      "integrity": "sha512-CBCRqFnpu715iPmw1KrdOrzRqbdFwQTwAWyyyYS42+iAgHCuXZ+/TdMgQkUENPomxEz9z1BEzuQU2Xw0kUuAgA==",
+      "dev": true
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -4827,7 +4864,6 @@
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "esutils": "^2.0.2"
       }
@@ -5391,6 +5427,28 @@
         }
       }
     },
+    "eslint-config-airbnb": {
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-17.1.1.tgz",
+      "integrity": "sha512-xCu//8a/aWqagKljt+1/qAM62BYZeNq04HmdevG5yUGWpja0I/xhqd6GdLRch5oetEGFiJAnvtGuTEAese53Qg==",
+      "dev": true,
+      "requires": {
+        "eslint-config-airbnb-base": "^13.2.0",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.1.0"
+      }
+    },
+    "eslint-config-airbnb-base": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.2.0.tgz",
+      "integrity": "sha512-1mg/7eoB4AUeB0X1c/ho4vb2gYkNH8Trr/EgCT/aGmKhhG+F6vF5s8+iRBlWAzFIAphxIdp3YfEKgEl0f9Xg+w==",
+      "dev": true,
+      "requires": {
+        "confusing-browser-globals": "^1.0.5",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.1.0"
+      }
+    },
     "eslint-config-standard": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz",
@@ -5600,6 +5658,23 @@
         }
       }
     },
+    "eslint-plugin-jsx-a11y": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
+      "integrity": "sha512-CawzfGt9w83tyuVekn0GDPU9ytYtxyxyFZ3aSWROmnRRFQFT2BiPJd7jvRdzNDi6oLWaS2asMeYSNMjWTV4eNg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.4.5",
+        "aria-query": "^3.0.0",
+        "array-includes": "^3.0.3",
+        "ast-types-flow": "^0.0.7",
+        "axobject-query": "^2.0.2",
+        "damerau-levenshtein": "^1.0.4",
+        "emoji-regex": "^7.0.2",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.2.1"
+      }
+    },
     "eslint-plugin-node": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-8.0.1.tgz",
@@ -5627,6 +5702,23 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz",
       "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
       "dev": true
+    },
+    "eslint-plugin-react": {
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
+      "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "doctrine": "^2.1.0",
+        "has": "^1.0.3",
+        "jsx-ast-utils": "^2.1.0",
+        "object.entries": "^1.1.0",
+        "object.fromentries": "^2.0.0",
+        "object.values": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "resolve": "^1.10.1"
+      }
     },
     "eslint-plugin-standard": {
       "version": "4.0.0",
@@ -6517,7 +6609,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6538,12 +6631,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6558,17 +6653,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6685,7 +6783,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6697,6 +6796,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6711,6 +6811,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6718,12 +6819,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6742,6 +6845,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6822,7 +6926,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6834,6 +6939,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6919,7 +7025,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6955,6 +7062,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6974,6 +7082,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7017,12 +7126,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -9554,6 +9665,16 @@
         "verror": "1.10.0"
       }
     },
+    "jsx-ast-utils": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
+      "integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.0.3",
+        "object.assign": "^4.1.0"
+      }
+    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -10543,6 +10664,30 @@
         "function-bind": "^1.1.1",
         "has-symbols": "^1.0.0",
         "object-keys": "^1.0.11"
+      }
+    },
+    "object.entries": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.12.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      }
+    },
+    "object.fromentries": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
+      "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.11.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1"
       }
     },
     "object.getownpropertydescriptors": {
@@ -11829,6 +11974,17 @@
         "sisteransi": "^0.1.1"
       }
     },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
+    },
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -12013,6 +12169,12 @@
         "unpipe": "1.0.0"
       }
     },
+    "react-is": {
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+      "dev": true
+    },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -12076,7 +12238,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -12513,7 +12675,8 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -19,6 +19,42 @@
     </div>
 </template>
 
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+import { AuthenticationStatus } from './store';
+
+@Component
+export default class App extends Vue {
+    mounted() {
+        this.$store.watch(
+            (state, getters) => getters.authStatus,
+            (newValue : AuthenticationStatus, oldValue : AuthenticationStatus) => {
+                if (newValue === AuthenticationStatus.In) {
+                    this.$toast.open({
+                        message: 'Login successful.',
+                        type: 'is-success'
+                    });
+                } else if (newValue === AuthenticationStatus.Out) {
+                    this.$toast.open({
+                        message: 'Logout successful.'
+                    });
+                } else if (newValue === AuthenticationStatus.Error) {
+                    this.$toast.open({
+                        message: 'Login failed!',
+                        type: 'is-danger'
+                    });
+                } else if (newValue === AuthenticationStatus.Prompt) {
+                    this.$toast.open({
+                        message: 'Please login.',
+                        type: 'is-warning'
+                    });
+                }
+            }
+        );
+    }
+}
+</script>
+
 <style lang="scss">
     #app {
         font-family: 'Avenir', Helvetica, Arial, sans-serif;

--- a/frontend/src/dashboard/Authentication.vue
+++ b/frontend/src/dashboard/Authentication.vue
@@ -1,13 +1,5 @@
 <template>
     <form class="login" @submit.prevent="login">
-        <b-notification
-            :type="errorType"
-            :active.sync="errorActive"
-            auto-close
-            aria-close-label="Close notification"
-            role="alert"
-        >{{errorMessage}}
-        </b-notification>
         <div v-if="!this.$store.getters.isAuthenticated">
             <b-field>
                 <b-input placeholder="Name" minlength="1" type="text" required v-model="name">
@@ -29,25 +21,24 @@
                 @click="login()"
             >Login</b-button>
         </div>
-        <b-button class="is-fullwidth" v-if="this.$store.getters.isAuthenticated" @click="logout()">
-            Logout
-        </b-button>
+        <div v-if="this.$store.getters.isAuthenticated">
+                <b-icon icon="account" size="is-small">
+                </b-icon> {{this.$store.getters.username}}
+            <b-button class="is-fullwidth"  @click="logout()">
+                Logout
+            </b-button>
+        </div>
     </form>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
-import axios from 'axios';
 import { AuthenticationStatus } from '../store';
 
 @Component
 export default class Authentication extends Vue {
     name: string = '';
     password: string = '';
-    showInputs: boolean = false;
-    errorActive: boolean = false;
-    errorMessage: string = '';
-    errorType: string = ''
 
     get missingInput() {
         return this.name.length === 0 || this.password.length === 0;
@@ -67,35 +58,6 @@ export default class Authentication extends Vue {
 
         this.$store.dispatch('logout')
             .catch(err => console.log(err));
-    }
-
-    mounted() {
-        this.$store.watch(
-            (state, getters) => getters.authStatus,
-            (newValue : AuthenticationStatus, oldValue : AuthenticationStatus) => {
-                if (newValue === AuthenticationStatus.In) {
-                    this.errorType = 'is-success';
-                    this.errorMessage = 'Login successful';
-                    this.errorActive = true;
-                } else if (newValue === AuthenticationStatus.Out) {
-                    this.errorType = '';
-                    this.errorMessage = 'Logout successful';
-                    this.errorActive = true;
-                } else if (newValue === AuthenticationStatus.Pending) {
-                    this.errorType = '';
-                    this.errorMessage = 'Logging in...';
-                    this.errorActive = true;
-                } else if (newValue === AuthenticationStatus.Error) {
-                    this.errorType = 'is-danger';
-                    this.errorMessage = 'Login failed';
-                    this.errorActive = true;
-                } else if (newValue === AuthenticationStatus.Prompt) {
-                    this.errorType = 'is-warning';
-                    this.errorMessage = 'Please login';
-                    this.errorActive = true;
-                }
-            }
-        );
     }
 }
 </script>

--- a/frontend/src/dashboard/Authentication.vue
+++ b/frontend/src/dashboard/Authentication.vue
@@ -47,17 +47,13 @@ export default class Authentication extends Vue {
     login() {
         const { name } = this;
         const { password } = this;
-
-        this.$store.dispatch('login', { name, password })
-            .catch(err => console.log(err));
+        this.$store.dispatch('login', { name, password });
     }
 
     logout() {
         this.name = '';
         this.password = '';
-
-        this.$store.dispatch('logout')
-            .catch(err => console.log(err));
+        this.$store.dispatch('logout');
     }
 }
 </script>

--- a/frontend/src/dashboard/Authentication.vue
+++ b/frontend/src/dashboard/Authentication.vue
@@ -1,13 +1,14 @@
 <template>
-    <div>
-        <div v-if="!isAuthenticated">
-            <b-notification
-                :type="errorType"
-                :active.sync="errorActive"
-                auto-close
-                aria-close-label="Close notification"
-                role="alert"
-            >{{errorMessage}}</b-notification>
+    <form class="login" @submit.prevent="login">
+        <b-notification
+            :type="errorType"
+            :active.sync="errorActive"
+            auto-close
+            aria-close-label="Close notification"
+            role="alert"
+        >{{errorMessage}}
+        </b-notification>
+        <div v-if="!this.$store.getters.isAuthenticated">
             <b-field>
                 <b-input placeholder="Name" minlength="1" type="text" required v-model="name">
                 </b-input>
@@ -23,17 +24,21 @@
             </b-field>
             <b-button
                 :disabled="missingInput"
+                type="submit"
                 class="button is-fullwidth"
                 @click="login()"
             >Login</b-button>
         </div>
-        <b-button class="is-fullwidth" v-if="isAuthenticated" @click="logout()">Logout</b-button>
-    </div>
+        <b-button class="is-fullwidth" v-if="this.$store.getters.isAuthenticated" @click="logout()">
+            Logout
+        </b-button>
+    </form>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import axios from 'axios';
+import { AuthenticationStatus } from '../store';
 
 @Component
 export default class Authentication extends Vue {
@@ -44,55 +49,51 @@ export default class Authentication extends Vue {
     errorMessage: string = '';
     errorType: string = ''
 
-    get isAuthenticated() {
-        return this.$store.state.authentication.authenticated;
-    }
-
     get missingInput() {
         return this.name.length === 0 || this.password.length === 0;
     }
 
     login() {
-        axios
-            .get(`${this.$store.state.backendURI}user/${this.name}`, {
-                auth: {
-                    username: this.name,
-                    password: this.password
-                }
-            })
-            .then((data) => {
-                this.$store.commit({
-                    type: 'login',
-                    name: this.name,
-                    password: this.password
-                });
-            })
-            .catch((error) => {
-                if (error.response === undefined) {
-                    this.errorMessage =
-                        'Failed to connect to server.';
-                    this.errorType = 'is-danger';
-                    this.errorActive = true;
-                }
-                if (error.response.status === 401) {
-                    this.errorMessage =
-                        'Your credentials seem to be invalid, please try again.';
+        const { name } = this;
+        const { password } = this;
 
-                    this.errorType = 'is-warning';
-                    this.errorActive = true;
-                } else {
-                    console.error('Invalid Server Response:', error.response);
-                }
-            });
+        this.$store.dispatch('login', { name, password })
+            .then(() => console.log('Logged in!'))
+            .catch(err => console.log(err));
     }
 
     logout() {
         this.name = '';
         this.password = '';
 
-        this.$store.commit({
-            type: 'logout'
-        });
+        this.$store.dispatch('logout')
+            .then(() => console.log('Logged in!'))
+            .catch(err => console.log(err));
+    }
+
+    mounted() {
+        this.$store.watch(
+            (state, getters) => getters.authStatus,
+            (newValue : AuthenticationStatus, oldValue : AuthenticationStatus) => {
+                if (newValue === AuthenticationStatus.In) {
+                    this.errorType = 'is-success';
+                    this.errorMessage = 'Login successful';
+                    this.errorActive = true;
+                } else if (newValue === AuthenticationStatus.Out) {
+                    this.errorType = 'is-success';
+                    this.errorMessage = 'Logout successful';
+                    this.errorActive = true;
+                } else if (newValue === AuthenticationStatus.Pending) {
+                    this.errorType = '';
+                    this.errorMessage = 'Logging in...';
+                    this.errorActive = true;
+                } else if (newValue === AuthenticationStatus.Error) {
+                    this.errorType = 'is-danger';
+                    this.errorMessage = 'Login failed';
+                    this.errorActive = true;
+                }
+            }
+        );
     }
 }
 </script>

--- a/frontend/src/dashboard/Authentication.vue
+++ b/frontend/src/dashboard/Authentication.vue
@@ -58,7 +58,6 @@ export default class Authentication extends Vue {
         const { password } = this;
 
         this.$store.dispatch('login', { name, password })
-            .then(() => console.log('Logged in!'))
             .catch(err => console.log(err));
     }
 
@@ -67,7 +66,6 @@ export default class Authentication extends Vue {
         this.password = '';
 
         this.$store.dispatch('logout')
-            .then(() => console.log('Logged in!'))
             .catch(err => console.log(err));
     }
 
@@ -80,7 +78,7 @@ export default class Authentication extends Vue {
                     this.errorMessage = 'Login successful';
                     this.errorActive = true;
                 } else if (newValue === AuthenticationStatus.Out) {
-                    this.errorType = 'is-success';
+                    this.errorType = '';
                     this.errorMessage = 'Logout successful';
                     this.errorActive = true;
                 } else if (newValue === AuthenticationStatus.Pending) {
@@ -90,6 +88,10 @@ export default class Authentication extends Vue {
                 } else if (newValue === AuthenticationStatus.Error) {
                     this.errorType = 'is-danger';
                     this.errorMessage = 'Login failed';
+                    this.errorActive = true;
+                } else if (newValue === AuthenticationStatus.Prompt) {
+                    this.errorType = 'is-warning';
+                    this.errorMessage = 'Please login';
                     this.errorActive = true;
                 }
             }

--- a/frontend/src/dashboard/Dashboard.vue
+++ b/frontend/src/dashboard/Dashboard.vue
@@ -4,7 +4,7 @@
             <div class="tile is-4 is-vertical is-parent">
                 <div class="tile is-child">
                     <MainMenu />
-                    <hr v-if="$store.state.authentication.authenticated">
+                    <hr v-if="this.$store.getters.isAuthenticated">
                     <JobList />
                 </div>
             </div>

--- a/frontend/src/dashboard/JobList.vue
+++ b/frontend/src/dashboard/JobList.vue
@@ -1,6 +1,10 @@
 <template>
-    <div v-if="isAuthenticated">
-        <h3 class="is-size-5">Your active jobs</h3>
+    <div v-if="this.$store.getters.isAuthenticated">
+        <h3 class="is-size-5">
+            Your active jobs
+             <a @click="updateJobList"><b-icon icon="refresh" size="is-small">
+            </b-icon></a>
+        </h3>
         <div v-for="job in jobList" :key="job['job_id']">
             <router-link class="message" :to="{ name: 'job', query: { id: job['job_id'] }}">
                 <div class="message-header">
@@ -30,13 +34,6 @@ import axios from 'axios';
 export default class JobList extends Vue {
     jobList: object[] = [];
 
-    get isAuthenticated() {
-        if (this.$store.state.authentication.authenticated) {
-            this.updateJobList();
-        }
-        return this.$store.state.authentication.authenticated;
-    }
-
     iconAttributesForState = (state : string) => {
         if (state === 'new') {
             return [{ icon: 'alarm' }];
@@ -50,20 +47,28 @@ export default class JobList extends Vue {
 
     updateJobList() {
         axios
-            .get(`${this.$store.state.backendURI}job/jobs`, {
-                auth: {
-                    username: this.$store.state.authentication.credentials
-                        .name,
-                    password: this.$store.state.authentication.credentials
-                        .password
-                }
-            })
+            .get(`${this.$store.state.backendURI}job/jobs`)
             .then((response) => {
                 this.jobList = response.data;
             })
             .catch((error) => {
                 console.error('Invalid Server Response:', error.response);
             });
+    }
+
+    mounted() {
+        if (this.$store.getters.isAuthenticated) {
+            this.updateJobList();
+        }
+
+        this.$store.watch(
+            (state, getters) => getters.isAuthenticated,
+            (newValue: boolean, oldValue: boolean) => {
+                if (newValue) {
+                    this.updateJobList();
+                }
+            }
+        );
     }
 }
 </script>

--- a/frontend/src/dashboard/JobList.vue
+++ b/frontend/src/dashboard/JobList.vue
@@ -45,15 +45,13 @@ export default class JobList extends Vue {
         return [{ type: 'is-danger' }, { icon: 'alert' }];
     }
 
-    updateJobList() {
-        axios
-            .get(`${this.$store.state.backendURI}job/jobs`)
-            .then((response) => {
-                this.jobList = response.data;
-            })
-            .catch((error) => {
-                console.error('Invalid Server Response:', error.response);
-            });
+    async updateJobList() {
+        try {
+            const response = await axios.get(`${this.$store.state.backendURI}job/jobs`)
+            this.jobList = response.data;
+        } catch (error) {
+            console.error('Invalid Server Response:', error.response);
+        }
     }
 
     mounted() {

--- a/frontend/src/job/ingest-journal/JournalImport.vue
+++ b/frontend/src/job/ingest-journal/JournalImport.vue
@@ -76,13 +76,7 @@ export default class JournalImport extends Vue {
     startJob() {
         axios.post(
             `${this.$store.state.backendURI}job/ingest_journal`,
-            this.jobParameters,
-            {
-                auth: {
-                    username: this.$store.state.authentication.credentials.name,
-                    password: this.$store.state.authentication.credentials.password
-                }
-            }
+            this.jobParameters
         )
             .then((response) => {
                 console.log(response);

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -19,7 +19,6 @@ const password = localStorage.getItem('password')
 
 if (username && password) {
     store.dispatch('login', { name: username, password: password })
-        .then(() => console.log('Success!'))
         .catch(err => console.log(err));
 }
 
@@ -29,7 +28,8 @@ router.beforeEach((to, from, next) => {
             next()
         }
         else {
-            // TODO: Display warning, there is currently no visible feedback for the redirects
+            store.dispatch('promptLogin')
+                .catch(err => console.error(err));
             next('/')
         }
     } else {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,4 +1,5 @@
 import Vue from 'vue';
+import Axios from 'axios'
 import Buefy from 'buefy';
 import router from './router';
 import store from './store';
@@ -12,8 +13,32 @@ Vue.use(Buefy, {
 
 Vue.config.productionTip = false;
 
+Vue.prototype.$http = Axios;
+const username = localStorage.getItem('username')
+const password = localStorage.getItem('password')
+
+if (username && password) {
+    store.dispatch('login', { name: username, password: password })
+        .then(() => console.log('Success!'))
+        .catch(err => console.log(err));
+}
+
+router.beforeEach((to, from, next) => {
+    if (to.matched.some(record => record.meta.requiresAuth)) {
+        if (store.getters.isAuthenticated) {
+            next()
+        }
+        else {
+            // TODO: Display warning, there is currently no visible feedback for the redirects
+            next('/')
+        }
+    } else {
+        next()
+    }
+})
+
 new Vue({
     router,
     store,
     render: h => h(App)
-}).$mount('#app');
+}).$mount('#app')

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -30,7 +30,8 @@ router.beforeEach((to, from, next) => {
         else {
             store.dispatch('promptLogin')
                 .catch(err => console.error(err));
-            next('/')
+            // next('/') // redirects if not authenticated
+            next()
         }
     } else {
         next()

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import Axios from 'axios'
+import Axios from 'axios';
 import Buefy from 'buefy';
 import router from './router';
 import store from './store';
@@ -14,32 +14,31 @@ Vue.use(Buefy, {
 Vue.config.productionTip = false;
 
 Vue.prototype.$http = Axios;
-const username = localStorage.getItem('username')
-const password = localStorage.getItem('password')
+const username = localStorage.getItem('username');
+const password = localStorage.getItem('password');
 
 if (username && password) {
-    store.dispatch('login', { name: username, password: password })
+    store.dispatch('login', { name: username, password })
         .catch(err => console.log(err));
 }
 
 router.beforeEach((to, from, next) => {
     if (to.matched.some(record => record.meta.requiresAuth)) {
         if (store.getters.isAuthenticated) {
-            next()
-        }
-        else {
+            next();
+        } else {
             store.dispatch('promptLogin')
                 .catch(err => console.error(err));
             // next('/') // redirects if not authenticated
-            next()
+            next();
         }
     } else {
-        next()
+        next();
     }
-})
+});
 
 new Vue({
     router,
     store,
     render: h => h(App)
-}).$mount('#app')
+}).$mount('#app');

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -18,18 +18,19 @@ const username = localStorage.getItem('username');
 const password = localStorage.getItem('password');
 
 if (username && password) {
-    store.dispatch('login', { name: username, password })
-        .catch(err => console.log(err));
+    try {
+        store.dispatch('login', { name: username, password })
+    } catch (err) {
+        console.log(err);
+    }
 }
 
-router.beforeEach((to, from, next) => {
+router.beforeEach(async (to, from, next) => {
     if (to.matched.some(record => record.meta.requiresAuth)) {
         if (store.getters.isAuthenticated) {
             next();
         } else {
-            store.dispatch('promptLogin')
-                .catch(err => console.error(err));
-            // next('/') // redirects if not authenticated
+            store.dispatch('promptLogin');
             next();
         }
     } else {

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -19,17 +19,26 @@ export default new Router({
         {
             path: '/staging',
             name: 'staging',
-            component: StagingArea
+            component: StagingArea,
+            meta: {
+                requiresAuth: true
+            }
         },
         {
             path: '/JournalImport',
             name: 'JournalImport',
-            component: JournalImport
+            component: JournalImport,
+            meta: {
+                requiresAuth: true
+            }
         },
         {
             path: '/job',
             name: 'job',
-            component: JobDetails
+            component: JobDetails,
+            meta: {
+                requiresAuth: true
+            }
         }
     ]
-});
+})

--- a/frontend/src/staging/FileBrowser.vue
+++ b/frontend/src/staging/FileBrowser.vue
@@ -30,13 +30,7 @@ export default class FileBrowser extends Vue {
 
     fetchFiles() {
         axios.get(
-            `${this.$store.state.backendURI}${this.dirToShow}`,
-            {
-                auth: {
-                    username: this.$store.state.authentication.credentials.name,
-                    password: this.$store.state.authentication.credentials.password
-                }
-            }
+            `${this.$store.state.backendURI}${this.dirToShow}`
         ).then((response) => {
             this.filesToShow = response.data;
         }).catch((error) => {

--- a/frontend/src/staging/StagingArea.vue
+++ b/frontend/src/staging/StagingArea.vue
@@ -42,13 +42,7 @@ export default class StagingArea extends Vue {
 
         fetchFiles() {
             axios.get(
-                `${this.$store.state.backendURI}staging`,
-                {
-                    auth: {
-                        username: this.$store.state.authentication.credentials.name,
-                        password: this.$store.state.authentication.credentials.password
-                    }
-                }
+                `${this.$store.state.backendURI}staging`
             ).then((response) => {
                 this.stagedFiles = response.data;
             }).catch((error) => {
@@ -93,10 +87,6 @@ export default class StagingArea extends Vue {
                 {
                     headers: {
                         'Content-Type': 'multipart/form-data'
-                    },
-                    auth: {
-                        username: this.$store.state.authentication.credentials.name,
-                        password: this.$store.state.authentication.credentials.password
                     }
                 }
             ).then(() => {

--- a/frontend/src/staging/UploadFiles.vue
+++ b/frontend/src/staging/UploadFiles.vue
@@ -1,5 +1,5 @@
 <template>
-    <section v-show="isLoggedIn">
+    <section v-show="this.$store.getters.isAuthenticated">
         <b-field>
             <b-upload v-model="filesToUpload"
                       multiple
@@ -48,10 +48,6 @@ export default class UploadFiles extends Vue {
         @Prop() running!: boolean
         @Prop() uploadedFiles!: number
         @Prop() totalFiles!: number
-
-        get isLoggedIn() {
-            return this.$store.state.authentication.authenticated
-        }
 
         deleteFileToUpload(index: number) {
             this.filesToUpload.splice(index, 1)

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -24,62 +24,57 @@ export default new Vuex.Store({
     },
     mutations: {
         auth_prompt: (state) => {
-            state.authentication.status = AuthenticationStatus.Prompt
+            state.authentication.status = AuthenticationStatus.Prompt;
         },
         auth_request: (state) => {
-            state.authentication.status = AuthenticationStatus.Pending
+            state.authentication.status = AuthenticationStatus.Pending;
         },
         auth_success: (state, [user, password]) => {
-            state.authentication.status = AuthenticationStatus.In
-            state.authentication.credentials.name = user
-            state.authentication.credentials.password = password
+            state.authentication.status = AuthenticationStatus.In;
+            state.authentication.credentials.name = user;
+            state.authentication.credentials.password = password;
         },
         auth_error: (state) => {
-            state.authentication.status = AuthenticationStatus.Error
+            state.authentication.status = AuthenticationStatus.Error;
         },
 
         logout: (state) => {
-            state.authentication.status = AuthenticationStatus.Out
-        },
+            state.authentication.status = AuthenticationStatus.Out;
+        }
     },
     actions: {
-        login: ({ commit }, user) => {
-            return new Promise((resolve, reject) => {
-                commit('auth_request')
-                axios({
-                    url: 'http://localhost:5000/user/' + user.name,
-                    auth: { username: user.name, password: user.password }, method: 'GET'
+        login: ({ commit }, user) => new Promise((resolve, reject) => {
+            commit('auth_request');
+            axios({
+                url: `http://localhost:5000/user/${user.name}`,
+                auth: { username: user.name, password: user.password },
+                method: 'GET'
+            })
+                .then((resp) => {
+                    localStorage.setItem('username', user.name);
+                    localStorage.setItem('password', user.password);
+                    axios.defaults.headers.common.Authorization = `Basic ${btoa(`${user.name}:${user.password}`)}`;
+                    commit('auth_success', user.name, user.password);
+                    resolve(resp);
                 })
-                    .then(resp => {
-                        localStorage.setItem('username', user.name)
-                        localStorage.setItem('password', user.password)
-                        axios.defaults.headers.common['Authorization'] = 'Basic ' + btoa(user.name + ':' + user.password);
-                        commit('auth_success', user.name, user.password)
-                        resolve(resp)
-                    })
-                    .catch(err => {
-                        commit('auth_error')
-                        localStorage.removeItem('username')
-                        localStorage.removeItem('password')
-                        reject(err)
-                    })
-            })
-        },
-        logout: ({ commit }) => {
-            return new Promise((resolve, reject) => {
-                commit('logout')
-                localStorage.removeItem('username')
-                localStorage.removeItem('password')
-                delete axios.defaults.headers.common['Authorization']
-                resolve()
-            })
-        },
-        promptLogin: ({ commit }) => {
-            return new Promise((resolve, reject) => {
-                commit('auth_prompt')
-                resolve()
-            })
-        }
+                .catch((err) => {
+                    commit('auth_error');
+                    localStorage.removeItem('username');
+                    localStorage.removeItem('password');
+                    reject(err);
+                });
+        }),
+        logout: ({ commit }) => new Promise((resolve, reject) => {
+            commit('logout');
+            localStorage.removeItem('username');
+            localStorage.removeItem('password');
+            delete axios.defaults.headers.common.Authorization;
+            resolve();
+        }),
+        promptLogin: ({ commit }) => new Promise((resolve, reject) => {
+            commit('auth_prompt');
+            resolve();
+        })
     },
     getters: {
         isAuthenticated: state => (state.authentication.status === AuthenticationStatus.In),

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -5,7 +5,7 @@ import axios from 'axios';
 Vue.use(Vuex);
 
 export enum AuthenticationStatus {
-    In, Out, Pending, Error
+    In, Out, Pending, Error, Prompt
 }
 
 export default new Vuex.Store({
@@ -23,6 +23,9 @@ export default new Vuex.Store({
         }
     },
     mutations: {
+        auth_prompt: (state) => {
+            state.authentication.status = AuthenticationStatus.Prompt
+        },
         auth_request: (state) => {
             state.authentication.status = AuthenticationStatus.Pending
         },
@@ -34,6 +37,7 @@ export default new Vuex.Store({
         auth_error: (state) => {
             state.authentication.status = AuthenticationStatus.Error
         },
+
         logout: (state) => {
             state.authentication.status = AuthenticationStatus.Out
         },
@@ -67,6 +71,12 @@ export default new Vuex.Store({
                 localStorage.removeItem('username')
                 localStorage.removeItem('password')
                 delete axios.defaults.headers.common['Authorization']
+                resolve()
+            })
+        },
+        promptLogin: ({ commit }) => {
+            return new Promise((resolve, reject) => {
+                commit('auth_prompt')
                 resolve()
             })
         }

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -53,8 +53,9 @@ export default new Vuex.Store({
                 });
                 localStorage.setItem('username', user.name);
                 localStorage.setItem('password', user.password);
-                axios.defaults.headers.common.Authorization =
-                    `Basic ${btoa(`${user.name}:${user.password}`)}`;
+
+                const basicAuth = `Basic ${btoa(`${user.name}:${user.password}`)}`;
+                axios.defaults.headers.common.Authorization = basicAuth;
                 commit('auth_success', user.name, user.password);
                 resolve(response);
             } catch (err) {

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -53,7 +53,8 @@ export default new Vuex.Store({
                 });
                 localStorage.setItem('username', user.name);
                 localStorage.setItem('password', user.password);
-                axios.defaults.headers.common.Authorization = `Basic ${btoa(`${user.name}:${user.password}`)}`;
+                axios.defaults.headers.common.Authorization =
+                    `Basic ${btoa(`${user.name}:${user.password}`)}`;
                 commit('auth_success', user.name, user.password);
                 resolve(response);
             } catch (err) {

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -84,5 +84,6 @@ export default new Vuex.Store({
     getters: {
         isAuthenticated: state => (state.authentication.status === AuthenticationStatus.In),
         authStatus: state => state.authentication.status,
+        username: state => state.authentication.credentials.name
     }
 });

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -54,8 +54,9 @@ export default new Vuex.Store({
                 localStorage.setItem('username', user.name);
                 localStorage.setItem('password', user.password);
 
-                const basicAuth = `Basic ${btoa(`${user.name}:${user.password}`)}`;
-                axios.defaults.headers.common.Authorization = basicAuth;
+                const basicAuth = btoa(`${user.name}:${user.password}`);
+                axios.defaults.headers.common.Authorization = `Basic ${basicAuth}`;
+
                 commit('auth_success', user.name, user.password);
                 resolve(response);
             } catch (err) {

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -43,26 +43,25 @@ export default new Vuex.Store({
         }
     },
     actions: {
-        login: ({ commit }, user) => new Promise((resolve, reject) => {
+        login: ({ commit }, user) => new Promise(async (resolve, reject) => {
             commit('auth_request');
-            axios({
-                url: `http://localhost:5000/user/${user.name}`,
-                auth: { username: user.name, password: user.password },
-                method: 'GET'
-            })
-                .then((resp) => {
-                    localStorage.setItem('username', user.name);
-                    localStorage.setItem('password', user.password);
-                    axios.defaults.headers.common.Authorization = `Basic ${btoa(`${user.name}:${user.password}`)}`;
-                    commit('auth_success', user.name, user.password);
-                    resolve(resp);
-                })
-                .catch((err) => {
-                    commit('auth_error');
-                    localStorage.removeItem('username');
-                    localStorage.removeItem('password');
-                    reject(err);
+            try {
+                const response = await axios({
+                    url: `http://localhost:5000/user/${user.name}`,
+                    auth: { username: user.name, password: user.password },
+                    method: 'GET'
                 });
+                localStorage.setItem('username', user.name);
+                localStorage.setItem('password', user.password);
+                axios.defaults.headers.common.Authorization = `Basic ${btoa(`${user.name}:${user.password}`)}`;
+                commit('auth_success', user.name, user.password);
+                resolve(response);
+            } catch (err) {
+                commit('auth_error');
+                localStorage.removeItem('username');
+                localStorage.removeItem('password');
+                reject(err);
+            }
         }),
         logout: ({ commit }) => new Promise((resolve, reject) => {
             commit('logout');

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -4,6 +4,10 @@ import axios from 'axios';
 
 Vue.use(Vuex);
 
+export enum AuthenticationStatus {
+    In, Out, Pending, Error
+}
+
 export default new Vuex.Store({
     strict: process.env.NODE_ENV !== 'production',
     state: {
@@ -11,23 +15,64 @@ export default new Vuex.Store({
         backendURI: 'http://localhost:5000/',
 
         authentication: {
-            authenticated: false,
+            status: AuthenticationStatus.Out,
             credentials: {
-                name: '',
-                password: ''
+                name: localStorage.getItem('username') || '',
+                password: localStorage.getItem('password') || ''
             }
         }
     },
     mutations: {
-        login: (state, payload) => {
-            state.authentication.credentials.name = payload.name;
-            state.authentication.credentials.password = payload.password;
-            state.authentication.authenticated = true;
+        auth_request: (state) => {
+            state.authentication.status = AuthenticationStatus.Pending
+        },
+        auth_success: (state, [user, password]) => {
+            state.authentication.status = AuthenticationStatus.In
+            state.authentication.credentials.name = user
+            state.authentication.credentials.password = password
+        },
+        auth_error: (state) => {
+            state.authentication.status = AuthenticationStatus.Error
         },
         logout: (state) => {
-            state.authentication.credentials.name = '';
-            state.authentication.credentials.password = '';
-            state.authentication.authenticated = false;
+            state.authentication.status = AuthenticationStatus.Out
+        },
+    },
+    actions: {
+        login: ({ commit }, user) => {
+            return new Promise((resolve, reject) => {
+                commit('auth_request')
+                axios({
+                    url: 'http://localhost:5000/user/' + user.name,
+                    auth: { username: user.name, password: user.password }, method: 'GET'
+                })
+                    .then(resp => {
+                        localStorage.setItem('username', user.name)
+                        localStorage.setItem('password', user.password)
+                        axios.defaults.headers.common['Authorization'] = 'Basic ' + btoa(user.name + ':' + user.password);
+                        commit('auth_success', user.name, user.password)
+                        resolve(resp)
+                    })
+                    .catch(err => {
+                        commit('auth_error')
+                        localStorage.removeItem('username')
+                        localStorage.removeItem('password')
+                        reject(err)
+                    })
+            })
+        },
+        logout: ({ commit }) => {
+            return new Promise((resolve, reject) => {
+                commit('logout')
+                localStorage.removeItem('username')
+                localStorage.removeItem('password')
+                delete axios.defaults.headers.common['Authorization']
+                resolve()
+            })
         }
+    },
+    getters: {
+        isAuthenticated: state => (state.authentication.status === AuthenticationStatus.In),
+        authStatus: state => state.authentication.status,
     }
 });

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -43,28 +43,29 @@ export default new Vuex.Store({
         }
     },
     actions: {
-        login: ({ commit }, user) => new Promise(async (resolve, reject) => {
+        login: ({ commit }, user) => new Promise((resolve, reject) => {
             commit('auth_request');
-            try {
-                const response = await axios({
-                    url: `http://localhost:5000/user/${user.name}`,
-                    auth: { username: user.name, password: user.password },
-                    method: 'GET'
-                });
-                localStorage.setItem('username', user.name);
-                localStorage.setItem('password', user.password);
+            const response = axios({
+                url: `http://localhost:5000/user/${user.name}`,
+                auth: { username: user.name, password: user.password },
+                method: 'GET'
+            }).then(
+                (resp) => {
+                    localStorage.setItem('username', user.name);
+                    localStorage.setItem('password', user.password);
 
-                const basicAuth = btoa(`${user.name}:${user.password}`);
-                axios.defaults.headers.common.Authorization = `Basic ${basicAuth}`;
+                    const basicAuth = btoa(`${user.name}:${user.password}`);
+                    axios.defaults.headers.common.Authorization = `Basic ${basicAuth}`;
 
-                commit('auth_success', user.name, user.password);
-                resolve(response);
-            } catch (err) {
-                commit('auth_error');
-                localStorage.removeItem('username');
-                localStorage.removeItem('password');
-                reject(err);
-            }
+                    commit('auth_success', user.name, user.password);
+                    resolve(response);
+                }, (err) => {
+                    commit('auth_error');
+                    localStorage.removeItem('username');
+                    localStorage.removeItem('password');
+                    reject(err);
+                }
+            );
         }),
         logout: ({ commit }) => new Promise((resolve, reject) => {
             commit('logout');


### PR DESCRIPTION
Ich habe das wie besprochen nach dem Blog Eintrag angepasst (siehe http://dai-softsource.uni-koeln.de/issues/11187). Dort wird allerdings mit Tokens gearbeitet, was ich jetzt nicht noch zusätzlich im Backend implementiert habe. Was jetzt funktioniert:

* Logins werden im localStore gespeichert und man wird automatisch eingelogged wenn man die Seite neuläd.
* Man kann bestimmte Routes mit "requiresAuth" markieren .
* Wenn man eine "gesicherte" Route anwählt, wird momentan nur oben ein "Toast"-prompt angezeigt, der einen darauf hinweist, dass man sich einloggen soll.

Was man noch anpassen könnte: Aktuell wird im localStore nach den credentials geguckt, dann wird einmal getestet ob sie korrekt sind und dann ist man eingelogged. Alternativ könnte man es auch so umstellen, dass man erst einmal als direkt eingelogged gilt, wenn was im localStore gefunden wird und falls die credentials nicht stimmen, wird man im Hintergrund wieder rausgeschmissen. Die aktuelle Lösung hat auf jeden Fall eine gewisse Latenz. 

