### PR TITLE
Refactor job_db module

### DIFF
--- a/frontend/src/job/ingest-record/forms/RecordMetadataForm.vue
+++ b/frontend/src/job/ingest-record/forms/RecordMetadataForm.vue
@@ -84,14 +84,14 @@ async function populateAtomRecord(record: ObjectRecord): Promise<ObjectRecord> {
     }
     try {
         const atomRecord = await getAtomRecord(atomId);
-        return buildRecordRecord(record, atomRecord);
+        return buildRecordRecord(record, atomRecord, atomId);
     } catch (error) {
         const msg = `No Record with the extracted ID "${atomId}" found.`;
         return buildError(record, msg);
     }
 }
 
-async function buildRecordRecord(record: ObjectRecord, atomRecord: AtomRecord):
+async function buildRecordRecord(record: ObjectRecord, atomRecord: AtomRecord, atomId: string):
     Promise<ObjectRecord> {
     return {
         id: record.id,
@@ -102,7 +102,7 @@ async function buildRecordRecord(record: ObjectRecord, atomRecord: AtomRecord):
                 title: atomRecord.title,
                 created: atomRecord.dates[0].date,
                 author: [atomRecord.creators[0].authotized_form_of_name],
-                atom_id: String(atomRecord.reference_code)
+                atom_id: atomId
             }
         },
         remoteRecord: atomRecord,

--- a/service/job/job_controller.py
+++ b/service/job/job_controller.py
@@ -6,7 +6,7 @@ from flask import Blueprint, url_for, jsonify, request
 
 from service.errors import ApiError
 from service.user.user_service import auth
-from utils import job_db
+from utils.job_db import JobDb
 from utils import json_validation
 
 from service.job.jobs import IngestRecordsJob, IngestJournalsJob
@@ -97,7 +97,9 @@ def job_list():
     :return: A JSON object containing the list of job objects
     """
     user = auth.username()
+    job_db = JobDb()
     jobs = job_db.get_jobs_for_user(user)
+    job_db.close()
     show_all_jobs = request.args.get('show_all_jobs')
     response = []
     if not show_all_jobs or show_all_jobs == "false":
@@ -596,7 +598,9 @@ def job_status(job_id):
 
     :return: A JSON object containing the status info
     """
+    job_db = JobDb()
     job = job_db.get_job_by_id(job_id)
+    job_db.close()
 
     job['duration'] = str(datetime.timedelta(
         seconds=int((job['updated'] - job['created']).total_seconds())))

--- a/service/run_service.py
+++ b/service/run_service.py
@@ -13,10 +13,11 @@ from service.repository.repository_controller import repository_controller
 from service.user.user_controller import user_controller
 from service.atom.atom_controller import atom_controller
 from service.errors import ApiError
-from utils.job_db import start_db
+from utils.job_db import JobDb
 
 setup_logging()
-start_db()
+job_db = JobDb()
+job_db.start_db()
 
 app = Flask('cilantro')
 CORS(app, supports_credentials=True)

--- a/utils/job_db.py
+++ b/utils/job_db.py
@@ -3,169 +3,164 @@ import datetime
 
 from pymongo import MongoClient, DESCENDING, ReturnDocument
 
-client = MongoClient(os.environ['JOB_DB_URL'], int(os.environ['JOB_DB_PORT']))
-db = client[os.environ['JOB_DB_NAME']]
 
+class JobDb:
 
-def start_db():
-    create_index()
-    set_first_object_id()
+    job_db_url = os.environ['JOB_DB_URL']
+    job_db_port = int(os.environ['JOB_DB_PORT'])
+    job_db_name = os.environ['JOB_DB_NAME']
+    first_object_id = int(os.environ['FIRST_OBJECT_ID'])
 
+    def __init__(self):
+        self.db = self._get_db_client()
 
-def create_index():
-    """
-    Create index for faster lookup in database.
+    def close(self):
+        self.db.client.close()
 
-    The 2 fields that are used for lookup/update are indexed.
-    """
-    db.jobs.create_index([("job_id", DESCENDING),
-                          ("user", DESCENDING)])
+    def start_db(self):
+        self._create_index()
+        self._set_first_object_id()
 
+    def generate_unique_object_identifier(self):
+        """
+        Create the unique object identifier.
 
-def set_first_object_id():
-    if not db.objects.find_one({'next_object_id': {'$exists': True}}):
-        first_object_id = int(os.environ['FIRST_OBJECT_ID'])
-        db.objects.insert_one({'next_object_id': first_object_id})
+        This is NOT the whole object id, just the last part to ensure every object
+        is unique and the last characters are digits.
+        :return:
+        """
+        try:
+            return self.db.objects.find_one_and_update(
+                {'next_object_id': {'$exists': True}},
+                {'$inc': {'next_object_id': 1}},
+                return_document=ReturnDocument.AFTER
+            )['next_object_id']
+        except KeyError:
+            raise RuntimeError("The database doesn't seem to be initialized"
+                            "properly")
 
+    def get_jobs_for_user(self, user):
+        """
+        Find all jobs of the passed user in the job database.
 
-def generate_unique_object_identifier():
-    """
-    Create the unique object identifier.
+        :param str user: username to find jobs belonging to
+        :return: list of job objects
+        """
+        job_list = []
+        for job in self.db.jobs.find({"user": user, "parent_job_id": None}, {'_id': False}):
+            job_list.append(
+                self._expand_child_information(job)
+            )
+        return job_list
 
-    This is NOT the whole object id, just the last part to ensure every object
-    is unique and the last characters are digits.
-    :return:
-    """
-    try:
-        return db.objects.find_one_and_update(
-            {'next_object_id': {'$exists': True}},
-            {'$inc': {'next_object_id': 1}},
-            return_document=ReturnDocument.AFTER
-        )['next_object_id']
-    except KeyError:
-        raise RuntimeError("The database doesn't seem to be initialized"
-                           "properly")
+    def get_job_by_id(self, job_id):
+        """
+        Find job with the given job_id.
 
+        :param str job_id: job-id to be queried
+        :return: job object
+        """
+        job = self._expand_child_information(self.db.jobs.find_one(
+            {"job_id": job_id}, {'_id': False}))
+        return job
 
-def get_jobs_for_user(user):
-    """
-    Find all jobs of the passed user in the job database.
+    def add_job(self, job_id, user, job_type, parent_job_id, child_job_ids, parameters):
+        """
+        Add a job to the job database.
 
-    :param str user: username to find jobs belonging to
-    :return: list of job objects
-    """
-    job_list = []
-    for job in db.jobs.find({"user": user, "parent_job_id": None}, {'_id': False}):
-        job_list.append(
-            expand_child_information(job)
-        )
-    return job_list
+        :param str job_id: Cilantro-ID of the job
+        :param str user: username which started the job
+        :param str job_type: type of job, i.e. 'ingest_journals'
+        :param str parent_job_id: Cilantro-IDs of the parent job
+        :param list child_job_ids: Cilantro-IDs of the child jobs
+        :param dict parameters: Issue parameters
+        :return: None
+        """
+        timestamp = datetime.datetime.now()
+        job = {'job_id': job_id,
+            'user': user,
+            'job_type': job_type,
+            'name': f"{job_type}-{job_id}",
+            'parent_job_id': parent_job_id,
+            'child_job_ids': child_job_ids,
+            'state': 'new',
+            'created': timestamp,
+            'started': None,
+            'updated': timestamp,
+            'parameters': parameters,
+            'errors': []
+            }
 
+        self.db.jobs.insert_one(job)
 
-def get_job_by_id(job_id):
-    """
-    Find job with the given job_id.
+    def update_job_state(self, job_id, state, error=None):
+        """
+        Update a job to the job database with new state and updated timestamp.
 
-    :param str job_id: job-id to be queried
-    :return: job object
-    """
-    job = expand_child_information(db.jobs.find_one(
-        {"job_id": job_id}, {'_id': False}))
-    return job
+        If there is an error object passed then that is added to the list
+        of errors of that task. The errors are a list to  make it
+        possible to keep executing the task chain even though some tasks
+        throw errors. The errors are put into the job entry in the database
+        and can be collected later.
 
+        :param str job_id: Cilantro-ID of the job
+        :param str state: new state of the job
+        :param dict error: (optional) dict containig task name and error message
+        :return: None
+        """
+        timestamp = datetime.datetime.now()
+        updated_values = {'state': state, 'updated': timestamp}
+        if state == 'started':
+            updated_values['started'] = timestamp
+        self.db.jobs.update_many({"job_id": job_id},
+                            {'$set': updated_values})
+        if error:
+            self.db.jobs.update_many({"job_id": job_id},
+                                {'$push': {'errors': error}})
 
-def expand_child_information(job):
-    """
-    Expand child job information for parent job
-    :param job: Parent job to be expanded
-    :return: job object
-    """
-    if 'child_job_ids' in job:
-        children_with_status = []
-        for child_id in job['child_job_ids']:
-            child = db.jobs.find_one({'job_id': child_id}, {'_id': False})
-            children_with_status += [{'job_id': child_id,
-                                      'state': child['state'],
-                                      'type': child['job_type']}]
+    def set_job_children(self, job_id, child_job_ids):
+        timestamp = datetime.datetime.now()
+        updated_values = {'child_job_ids': child_job_ids, 'updated': timestamp}
+        self.db.jobs.update_many({"job_id": job_id},
+                            {'$set': updated_values})
 
-        del job['child_job_ids']
+    def add_job_error(self, job_id, error_message):
+        timestamp = datetime.datetime.now()
+        self.db.jobs.update_many({"job_id": job_id},
+                            {'$push': {'errors': error_message}, '$set': {'updated': timestamp}})
 
-        job['children'] = children_with_status
+    def _create_index(self):
+        """
+        Create index for faster lookup in database.
 
-    if 'parent_job_id' in job and job['parent_job_id'] == None:
-        del job['parent_job_id']
-    return job
+        The 2 fields that are used for lookup/update are indexed.
+        """
+        self.db.jobs.create_index([("job_id", DESCENDING), ("user", DESCENDING)])
 
+    def _set_first_object_id(self):
+        if not self.db.objects.find_one({'next_object_id': {'$exists': True}}):
+            self.db.objects.insert_one({'next_object_id': self.first_object_id})
 
-def add_job(job_id, user, job_type, parent_job_id, child_job_ids, parameters):
-    """
-    Add a job to the job database.
+    def _get_db_client(self):
+        return MongoClient(self.job_db_url, self.job_db_port)[self.job_db_name]
 
-    :param str job_id: Cilantro-ID of the job
-    :param str user: username which started the job
-    :param str job_type: type of job, i.e. 'ingest_journals'
-    :param list task_ids: Cilantro-IDs of all tasks belonging to that job
-    :param dict parameters: Issue parameters
-    :return: None
-    """
-    timestamp = datetime.datetime.now()
-    job = {'job_id': job_id,
-           'user': user,
-           'job_type': job_type,
-           'name': f"{job_type}-{job_id}",
-           'parent_job_id': parent_job_id,
-           'child_job_ids': child_job_ids,
-           'state': 'new',
-           'created': timestamp,
-           'started': None,
-           'updated': timestamp,
-           'parameters': parameters,
-           'errors': []
-           }
+    def _expand_child_information(self, job):
+        """
+        Expand child job information for parent job
+        :param job: Parent job to be expanded
+        :return: job object
+        """
+        if 'child_job_ids' in job:
+            children_with_status = []
+            for child_id in job['child_job_ids']:
+                child = self.db.jobs.find_one({'job_id': child_id}, {'_id': False})
+                children_with_status += [{'job_id': child_id,
+                                        'state': child['state'],
+                                        'type': child['job_type']}]
 
-    db.jobs.insert_one(job)
+            del job['child_job_ids']
+            job['children'] = children_with_status
 
-
-def update_job_state(job_id, state, error=None):
-    """
-    Update a job to the job database with new state and updated timestamp.
-
-    If there is an error object passed then that is added to the list
-    of errors of that task. The errors are a list to  make it
-    possible to keep executing the task chain even though some tasks
-    throw errors. The errors are put into the job entry in the database
-    and can be collected later.
-
-    :param str job_id: Cilantro-ID of the job
-    :param str state: new state of the job
-    :param dict error: (optional) dict containig task name and error message
-    :return: None
-    """
-    timestamp = datetime.datetime.now()
-
-    updated_values = {'state': state, 'updated': timestamp}
-
-    if state == 'started':
-        updated_values['started'] = timestamp
-
-    db.jobs.update_many({"job_id": job_id},
-                        {'$set': updated_values})
-    if error:
-        db.jobs.update_many({"job_id": job_id},
-                            {'$push': {'errors': error}})
-
-
-def set_job_children(job_id, child_job_ids):
-
-    timestamp = datetime.datetime.now()
-
-    updated_values = {'child_job_ids': child_job_ids, 'updated': timestamp}
-    db.jobs.update_many({"job_id": job_id},
-                        {'$set': updated_values})
-
-
-def add_job_error(job_id, error_message):
-
-    timestamp = datetime.datetime.now()
-    db.jobs.update_many({"job_id": job_id},
-                        {'$push': {'errors': error_message}, '$set': {'updated': timestamp}})
+        if 'parent_job_id' in job and job['parent_job_id'] is None:
+            del job['parent_job_id']
+        return job

--- a/workers/default/repository/tasks.py
+++ b/workers/default/repository/tasks.py
@@ -5,7 +5,7 @@ import glob
 from utils.celery_client import celery_app
 from workers.base_task import BaseTask, ObjectTask
 from utils.repository import generate_repository_path
-from utils.job_db import generate_unique_object_identifier
+from utils.job_db import JobDb
     
 repository_dir = os.environ['REPOSITORY_DIR']
 archive_dir = os.environ['ARCHIVE_DIR']
@@ -32,7 +32,10 @@ class CreateObjectTask(ObjectTask):
             object_id = self.get_param('id')
         except KeyError:
             object_id = self.job_id
-        return object_id + f"_{generate_unique_object_identifier()}"
+        job_db = JobDb()
+        uid = job_db.generate_unique_object_identifier()
+        job_db.close()
+        return object_id + f"_{uid}"
 
 
 CreateObjectTask = celery_app.register_task(CreateObjectTask())

--- a/workers/default/repository/tasks.py
+++ b/workers/default/repository/tasks.py
@@ -24,8 +24,9 @@ class CreateObjectTask(ObjectTask):
     name = "create_object"
 
     def process_object(self, obj):
-        _initialize_object(obj, self.params)
-        return {'object_id': self._get_object_id()}
+        oid = self._get_object_id()
+        _initialize_object(obj, self.params, oid)
+        return {'object_id': oid}
 
     def _get_object_id(self):
         try:
@@ -48,9 +49,9 @@ def _get_work_path(params):
     return abs_path
 
 
-def _initialize_object(obj, params):
+def _initialize_object(obj, params, oid):
     obj.set_metadata_from_dict(params['metadata'])
-    obj.metadata.id = params['id']
+    obj.metadata.id = oid
     _initialize_files(obj, params['path'], params['user'],
                       params['initial_representation'])
     obj.write()


### PR DESCRIPTION
This makes sure that connections are not reused accross forks
by implementing a class JobDb that has to be created and explicitly
closed when using the job database.

See #11513