### PR TITLE
Python3 und Pipenv Fixes

### DIFF
--- a/docker/cilantro-convert-worker/Dockerfile
+++ b/docker/cilantro-convert-worker/Dockerfile
@@ -23,7 +23,7 @@ ENV LANG C.UTF-8
 # workaround for pipenv bug: https://github.com/pypa/pipenv/issues/1328
 RUN set -ex && mkdir /app
 
-RUN pip3 install pipenv
+RUN pip3 install 'pipenv==2018.11.26'
 COPY docker/cilantro-convert-worker/Pipfile.lock Pipfile.lock
 COPY docker/cilantro-convert-worker/Pipfile Pipfile
 RUN set -ex && pipenv install --deploy --system

--- a/docker/cilantro-convert-worker/Dockerfile
+++ b/docker/cilantro-convert-worker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
     libtiff-dev \
     libpoppler-cpp-dev \
     pkg-config \
-    python-dev \
+    python3-dev \
     libmagickwand-dev \
     ghostscript \
     tesseract-ocr \

--- a/docker/cilantro-default-worker/Dockerfile
+++ b/docker/cilantro-default-worker/Dockerfile
@@ -20,7 +20,7 @@ ENV LANG C.UTF-8
 RUN set -ex && mkdir /app
 
 
-RUN pip3 install pipenv
+RUN pip3 install 'pipenv==2018.11.26'
 COPY docker/cilantro-default-worker/Pipfile.lock Pipfile.lock
 COPY docker/cilantro-default-worker/Pipfile Pipfile
 RUN set -ex && pipenv install --deploy --system

--- a/docker/cilantro-default-worker/Dockerfile
+++ b/docker/cilantro-default-worker/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && \
     build-essential \
     libpoppler-cpp-dev \
     pkg-config \
-    python-dev \
+    python3-dev \
     libmagickwand-dev \
     ghostscript
 

--- a/docker/cilantro-nlp-heideltime-worker/Dockerfile
+++ b/docker/cilantro-nlp-heideltime-worker/Dockerfile
@@ -17,7 +17,7 @@ ENV LANG C.UTF-8
 # workaround for pipenv bug: https://github.com/pypa/pipenv/issues/1328
 RUN set -ex && mkdir /app
 
-RUN pip3 install pipenv
+RUN pip3 install 'pipenv==2018.11.26'
 COPY docker/cilantro-nlp-heideltime-worker/Pipfile.lock Pipfile.lock
 COPY docker/cilantro-nlp-heideltime-worker/Pipfile Pipfile
 RUN set -ex && pipenv install --deploy --system

--- a/docker/cilantro-service/Dockerfile
+++ b/docker/cilantro-service/Dockerfile
@@ -5,7 +5,7 @@ ENV PIPENV_VENV_IN_PROJECT=true
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
 
-RUN apk add --update python-dev py-pip gcc libffi libffi-dev musl-dev
+RUN apk add --update python3-dev py-pip gcc libffi libffi-dev musl-dev
 
 # workaround for pipenv bug: https://github.com/pypa/pipenv/issues/1328
 RUN set -ex && mkdir /app

--- a/docker/cilantro-service/Dockerfile
+++ b/docker/cilantro-service/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --update python3-dev py-pip gcc libffi libffi-dev musl-dev
 # workaround for pipenv bug: https://github.com/pypa/pipenv/issues/1328
 RUN set -ex && mkdir /app
 
-RUN pip3 install pipenv
+RUN pip3 install 'pipenv==2018.11.26'
 COPY docker/cilantro-service/Pipfile.lock Pipfile.lock
 COPY docker/cilantro-service/Pipfile Pipfile
 RUN set -ex && pipenv install --deploy --system

--- a/docker/cilantro-test/Dockerfile
+++ b/docker/cilantro-test/Dockerfile
@@ -22,7 +22,7 @@ ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
 
 
-RUN pip3 install pipenv
+RUN pip3 install 'pipenv==2018.11.26'
 COPY docker/cilantro-test/Pipfile.lock Pipfile.lock
 COPY docker/cilantro-test/Pipfile Pipfile
 RUN set -ex && pipenv install --deploy --system


### PR DESCRIPTION
Durch das veralten von python2 und einem Pipenv Update konnten unsere Docker-container nicht mehr gebaut werden. `docker-compose build service --no-cache` schlug fehl. Diese PR sollte das erstmal beheben. Die Pipenv Version auf 2018 festzulegen scheint zwar nicht die schönste, aber praktischste Lösung zu sein.
Siehe https://github.com/pypa/pipenv/issues/4273.