### PR TITLE
Staging Area: Zenon Links & Auswählen von Unterordnern

### DIFF
--- a/frontend/src/job/JobParameters.ts
+++ b/frontend/src/job/JobParameters.ts
@@ -36,8 +36,10 @@ export function isTargetError(o: any) {
 
 export type MaybeJobTarget = JobTargetData | JobTargetError;
 
-export async function getTargetFolder(stagingFiles: WorkbenchFileTree, targetId: string) {
-    return getStagingFile(stagingFiles, targetId);
+export async function getTargetFolder(stagingFiles: WorkbenchFileTree, targetPath: string) {
+    // cut trailing /
+    if (targetPath.charAt(0) === "/") targetPath = targetPath.substr(1);
+    return getStagingFile(stagingFiles, targetPath);
 }
 
 function getStagingFile(stagingFiles: WorkbenchFileTree, path: string): WorkbenchFileTree | {} {
@@ -56,6 +58,6 @@ export function containsNumberOfFiles(folder: WorkbenchFileTree, number: number)
 export function containsOnlyFilesWithSuffix(folder: WorkbenchFileTree,
     suffix: string) {
     const differentSuffixFiles = Object.keys(folder).filter(file => !file.endsWith(suffix));
-    
+
     return differentSuffixFiles.length === 0;
 }

--- a/frontend/src/job/JobParameters.ts
+++ b/frontend/src/job/JobParameters.ts
@@ -37,7 +37,7 @@ export function isTargetError(o: any) {
 export type MaybeJobTarget = JobTargetData | JobTargetError;
 
 export async function getTargetFolder(stagingFiles: WorkbenchFileTree, targetPath: string) {
-    // cut trailing /
+    // cut leading /
     if (targetPath.charAt(0) === "/") targetPath = targetPath.substr(1);
     return getStagingFile(stagingFiles, targetPath);
 }

--- a/frontend/src/job/ingest-archival-material/IngestArchivalMaterialMetadataForm.vue
+++ b/frontend/src/job/ingest-archival-material/IngestArchivalMaterialMetadataForm.vue
@@ -110,7 +110,7 @@ export default class ArchivalMaterialMetadataForm extends Vue {
                     errors.push(`Could not extract Atom ID from ${path}.`);
                 }
 
-                const targetFolder = await getTargetFolder(stagingFiles, id);
+                const targetFolder = await getTargetFolder(stagingFiles, path);
                 if (Object.keys(targetFolder).length === 0) {
                     errors.push(`Could not find file at ${path}.`);
                 } else {

--- a/frontend/src/job/ingest-journal/IngestJournalMetadataForm.vue
+++ b/frontend/src/job/ingest-journal/IngestJournalMetadataForm.vue
@@ -40,6 +40,12 @@
                         label="Number"
                         >{{ props.row.metadata.number || '-' }}
                     </b-table-column>
+                    <b-table-column
+                        field="metadata.zenon_link"
+                        label="Zenon"
+                    ><a :href="'https://zenon.dainst.org/Record/' + props.row.metadata.zenon_id">
+                        {{props.row.metadata.zenon_id}}</a>
+                    </b-table-column>
                 </template>
                 <template v-else>
                     <b-table-column label="Description">-</b-table-column>

--- a/frontend/src/job/ingest-journal/IngestJournalMetadataForm.vue
+++ b/frontend/src/job/ingest-journal/IngestJournalMetadataForm.vue
@@ -118,7 +118,7 @@ export default class JournalMetadataForm extends Vue {
                     errors.push(`Could not extract Zenon ID from ${path}.`);
                 }
 
-                const targetFolder = await getTargetFolder(stagingFiles, id);
+                const targetFolder = await getTargetFolder(stagingFiles, path);
                 if (Object.keys(targetFolder).length === 0) {
                     errors.push(`Could not find file at ${path}.`);
                 } else {
@@ -167,7 +167,7 @@ function evaluateTargetFolder(targetFolder : WorkbenchFileTree) {
                 !containsOnlyFilesWithSuffix(targetFolder.tif.contents, '.tif')) {
             errors.push(`Subfolder 'tif' does not only contain files ending in '.tif'.`);
         }
-    } 
+    }
     return errors;
 }
 

--- a/frontend/src/job/ingest-monograph/IngestMonographMetadataForm.vue
+++ b/frontend/src/job/ingest-monograph/IngestMonographMetadataForm.vue
@@ -113,7 +113,7 @@ export default class MonographMetadataForm extends Vue {
                     errors.push(`Could not extract Zenon ID from ${path}.`);
                 }
 
-                const targetFolder = await getTargetFolder(stagingFiles, id);
+                const targetFolder = await getTargetFolder(stagingFiles, path);
                 if (Object.keys(targetFolder).length === 0) {
                     errors.push(`Could not find file at ${path}.`);
                 } else {


### PR DESCRIPTION
Löst die Tickets SD-324 und SD-325.

Links zum Zenon werden angezeigt, sobald die ID geparsed wurde und es können jetzt auch Unterordner für den Import ausgewählt werden.