### PR TITLE
Use a named external volume for workspace data in prod and test

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -183,6 +183,8 @@ volumes:
     external: true
   redis-data:
   workspace-data:
+    name: workbench_workspace_data
+    external: true
   repository-data:
     name: workbench_repository_data
     external: true

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -183,6 +183,8 @@ volumes:
     external: true
   redis-data:
   workspace-data:
+    name: workbench_workspace_data
+    external: true
   repository-data:
     name: workbench_repository_data
     external: true


### PR DESCRIPTION

Enables NFS volume connection in the test and prod portainers.