### PR TITLE
Autoescaping für generierte XML

### DIFF
--- a/workers/default/xml/xml_generator.py
+++ b/workers/default/xml/xml_generator.py
@@ -24,7 +24,7 @@ def generate_xml(obj, template_file, target_filepath, params):
         loader=FileSystemLoader('resources'),
         trim_blocks=True,
         lstrip_blocks=True,
-        autoescape=select_autoescape(['xml'])
+        autoescape=True
     )
 
     # Some functions which may be needed in the template (logic)

--- a/workers/default/xml/xml_generator.py
+++ b/workers/default/xml/xml_generator.py
@@ -5,7 +5,7 @@ import glob
 import json
 import base64
 
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 log = logging.getLogger(__name__)
 
@@ -23,7 +23,10 @@ def generate_xml(obj, template_file, target_filepath, params):
     env = Environment(
         loader=FileSystemLoader('resources'),
         trim_blocks=True,
-        lstrip_blocks=True)
+        lstrip_blocks=True,
+        autoescape=select_autoescape(['xml'])
+    )
+
     # Some functions which may be needed in the template (logic)
     env.globals['path_join'] = os.path.join
     env.globals['datetime'] = datetime

--- a/workers/task_information.py
+++ b/workers/task_information.py
@@ -40,7 +40,7 @@ information = {
     "finish_chord": {"label": "No label set for chord task",
                      "description": "No label set for chord task"},
     "generate_xml": {"label": "Generate XML",
-                     "description": "Creates an OJS import XML file."}
+                     "description": "Renders a XML file based on a given template."}
 }
 
 


### PR DESCRIPTION
SD-944 war ein Bug Report für den Archiv-Workflow. 

`xmlParseEntityRef: no name, line 20, column 45 (mets.xml, line 20)`

Wobei in Zeile 20 der Titeleintrag zu finden ist.

Das Problem war, dass einige Datensätze ein "&" im Titel oder anderen Feldern besaßen, was in XML reserviert ist. Ich habe einen Pull Request eröffnet, weil Jinja (die XML Templating Library) an sich davon abrät, automatisch zu escapen. Mir fällt gerade kein Grund ein, warum es bei uns zu Problemen führen könnte, oder fällt euch was ein?

Siehe: https://jinja.palletsprojects.com/en/2.11.x/templates/#html-escaping bzw. https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references#Predefined_entities_in_XML