### PR TITLE
SD-1611: Remove deprecated journal import option

### DIFF
--- a/frontend/src/job/ingest-journal/IngestJournal.vue
+++ b/frontend/src/job/ingest-journal/IngestJournal.vue
@@ -90,9 +90,6 @@ export default class IngestJournal extends Vue {
         super();
 
         const options = {
-            ojs_options: {
-                default_create_frontpage: true
-            } as OJSOptions,
             ocr_options: {
                 do_ocr: false,
                 ocr_lang: 'deu'

--- a/frontend/src/job/ingest-journal/IngestJournalOptionsForm.vue
+++ b/frontend/src/job/ingest-journal/IngestJournalOptionsForm.vue
@@ -2,14 +2,6 @@
     <section class="tile is-ancestor">
         <div class="tile is-parent">
             <div class="tile is-child box">
-                <p class="title">OJS Options</p>
-                <b-field>
-                    <b-switch
-                        v-model="options.ojs_options.default_create_frontpage"
-                    >Always create frontpage</b-switch>
-                </b-field>
-            </div>
-            <div class="tile is-child box">
                 <OCROptionsForm
                     :initialOptions="options.ocr_options"
                     @options-updated="options = $event"

--- a/frontend/src/job/ingest-journal/IngestJournalParameters.ts
+++ b/frontend/src/job/ingest-journal/IngestJournalParameters.ts
@@ -39,7 +39,6 @@ export class JournalIssueMetadata {
 }
 
 export interface IngestJournalOptions {
-    ojs_options: OJSOptions;
     ocr_options: OCROptions;
     app_options: AppOptions;
 }
@@ -49,5 +48,3 @@ export interface OJSOptions {
 }
 
 export type MaybeJobTarget = JobTargetData | JobTargetError;
-
-

--- a/frontend/tests/unit/job/ingest-journal/IngestJournal.spec.ts
+++ b/frontend/tests/unit/job/ingest-journal/IngestJournal.spec.ts
@@ -21,7 +21,6 @@ localVue.use(Vuex);
 const fakePath = './haus/vom/nikolaus/';
 const target = new JobTargetData('007', fakePath, new JournalIssueMetadata('0023456'));
 const options: IngestJournalOptions = {
-    ojs_options: { default_create_frontpage: true },
     ocr_options: {
         do_ocr: true,
         ocr_lang: ''

--- a/resources/job_parameter_schemas/ingest_journals_schema.json
+++ b/resources/job_parameter_schemas/ingest_journals_schema.json
@@ -71,27 +71,11 @@
         "options": {
             "type": "object",
             "required": [
-                "ojs_options",
                 "ocr_options",
                 "app_options"
             ],
             "additionalProperties": false,
             "properties": {
-                "ojs_options": {
-                    "type": "object",
-                    "required": [
-                        "default_create_frontpage"
-                    ],
-                    "additionalProperties": false,
-                    "properties": {
-                        "auto_publish_issue": {
-                            "type": "boolean"
-                        },
-                        "default_create_frontpage": {
-                            "type": "boolean"
-                        }
-                    }
-                },
                 "ocr_options": {
                     "type": "object",
                     "required": [

--- a/resources/ojs3_template_issue.xml
+++ b/resources/ojs3_template_issue.xml
@@ -1,5 +1,4 @@
 {% set metadata = obj.metadata %}
-{% set ojs_options = params['ojs_options'] %}
 {% set pdf_file_path = path_join(obj.get_representation_dir('pdf'), obj.id + '.pdf') %}
 <?xml version="1.0" encoding="UTF-8"?>
 <issue xmlns="http://pkp.sfu.ca" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" published="1" current="1" access_status="1"

--- a/service/job/job_controller.py
+++ b/service/job/job_controller.py
@@ -130,9 +130,6 @@ def job_list():
                         "ocr_options": {
                             "do_ocr": false,
                             "ocr_lang": "deu"
-                        },
-                        "ojs_options": {
-                            "default_create_frontpage": true
                         }
                     },
                     "targets": [
@@ -215,9 +212,6 @@ def journal_job_create():
                 }
             }],
             "options": {
-                "ojs_options": {
-                    "default_create_frontpage": true
-                },
                 "ocr_options": {
                     "do_ocr": true,
                     "ocr_lang": "deu"
@@ -626,25 +620,9 @@ def get_job_param_schema(job_type):
                                 "ocr_lang"
                             ],
                             "type": "object"
-                        },
-                        "ojs_options": {
-                            "additionalProperties": false,
-                            "properties": {
-                                "auto_publish_issue": {
-                                    "type": "boolean"
-                                },
-                                "default_create_frontpage": {
-                                    "type": "boolean"
-                                }
-                            },
-                            "required": [
-                                "default_create_frontpage"
-                            ],
-                            "type": "object"
                         }
                     },
                     "required": [
-                        "ojs_options",
                         "ocr_options",
                         "app_options"
                     ],

--- a/service/job/jobs.py
+++ b/service/job/jobs.py
@@ -339,8 +339,7 @@ class IngestJournalsJob(BatchJob):
 
             current_chain |= _link('generate_xml',
                                    template_file='ojs3_template_issue.xml',
-                                   target_filename='ojs_import.xml',
-                                   ojs_options=params['options']['ojs_options'])
+                                   target_filename='ojs_import.xml')
 
             current_chain |= _link('generate_xml',
                                    template_file='mets_template_journal.xml',
@@ -350,7 +349,6 @@ class IngestJournalsJob(BatchJob):
             current_chain |= _link('publish_to_repository')
 
             current_chain |= _link('publish_to_ojs',
-                                   ojs_metadata=params['options']['ojs_options'],
                                    ojs_journal_code=issue_target['metadata']['ojs_journal_code'])
 
             current_chain |= _link('publish_to_archive')

--- a/test/resources/params/journal.json
+++ b/test/resources/params/journal.json
@@ -15,9 +15,6 @@
         }
     ],
     "options": {
-        "ojs_options": {
-            "default_create_frontpage": true
-        },
         "ocr_options": {
             "do_ocr": true,
             "ocr_lang": "eng"


### PR DESCRIPTION
The option is passed both to the XML generator (which just initializes a variable but does not used it) and to the ojs worker, which does not seem to use it either.

See also https://github.com/dainst/ojs-cilantro-plugin for no mention of a frontmatter option.